### PR TITLE
fix bug on rewardDistributor split into 2 eras

### DIFF
--- a/contracts/RewardsDistributer.sol
+++ b/contracts/RewardsDistributer.sol
@@ -227,7 +227,7 @@ contract RewardsDistributer is IRewardsDistributer, Initializable, OwnableUpgrad
             rewardInfo.eraRewardAddTable[agreementStartEra] += firstEraReward;
 
             uint256 postEndEra = agreementStartEra + 2;
-            rewardInfo.eraRewardAddTable[agreementStartEra + 1] += lastEraReward < lastEraReward
+            rewardInfo.eraRewardAddTable[agreementStartEra + 1] += firstEraReward < lastEraReward
                 ? lastEraReward - firstEraReward
                 : firstEraReward - lastEraReward;
             rewardInfo.eraRewardRemoveTable[postEndEra] += lastEraReward;

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -18,7 +18,7 @@ import {
     Settings,
     InflationController,
 } from '../src';
-import {startNewEra, time, generateAgreement, etherParse} from './helper';
+import {startNewEra, time, generateAgreement, etherParse, timeTravel} from './helper';
 
 describe('RewardsDistributer Contract', () => {
     const mockProvider = waffle.provider;
@@ -99,7 +99,6 @@ describe('RewardsDistributer Contract', () => {
 
     describe('Rewards Split', async () => {
         beforeEach(async () => {
-            //a 30 days agreement with 400 rewards come in at Era2
             const agreement = await generateAgreement(
                 indexer.address,
                 consumer.address,
@@ -113,6 +112,20 @@ describe('RewardsDistributer Contract', () => {
             //await timeTravel(mockProvider, 1000);
             await rewardsDistributor.connect(root).increaseAgreementRewards(indexer.address, agreement.address);
         });
+        it('split rewards into 2 eras should work', async () => {
+            await timeTravel(mockProvider, 60*60*24*4);
+            const agreement = await generateAgreement(
+                indexer.address,
+                consumer.address,
+                5,
+                etherParse("3"),
+                root,
+                mockProvider,
+                DEPLOYMENT_ID,
+                settings
+            );
+            await rewardsDistributor.connect(root).increaseAgreementRewards(indexer.address, agreement.address);
+        })
         it('split rewards into eras should work', async () => {
             const currentEar = await (await eraManager.eraNumber()).toNumber();
 


### PR DESCRIPTION
Close [issue15](https://github.com/subquery/network-contracts/issues/15)
Note: 
Acala EVM is only revert with the originalError.data for this stage looks like: 
```
"data":{
    "code":6969,
    "message":"Error: -32603: VM Exception while processing transaction: execution revert:0x4e487b710000000000000000000000000000000000000000000000000000000000000011"
}
```
Usually on an common EVM we can get more specific error message looks like:
```
VM Exception while processing transaction: reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)
```
[This website](https://www.4byte.directory/signatures/?bytes4_signature=0x4e487b71) provides a tool that helps us to decode the Signatures of the revert message. 
And we can find the specific error on [solidity documentation](https://docs.soliditylang.org/en/v0.8.13/control-structures.html?highlight=0x11#panic-via-assert-and-error-via-require)