### PR TITLE
Update: use moonbase config as default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,16 @@ on:
     inputs:
       endpoint:
         description: 'endpoint used to deploy contracts'
-        default: https://acala-mandala.api.onfinality.io/public
+        default: https://moonbeam-alpha.api.onfinality.io/public
         required: true
       network:
         type: choice
         description: 'network used to publish contracts'
-        default: testnet
+        default: moonbase
         required: true
         options: 
-        - testnet
-        - moonbase
+          - moonbase
+          - testnet
 
 jobs:
   Deploy-Contracts:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -9,16 +9,16 @@ on:
     inputs:
       endpoint:
         description: 'endpoint used to deploy contracts'
-        default: https://acala-mandala.api.onfinality.io/public
+        default: https://moonbeam-alpha.api.onfinality.io/public
         required: true
       network:
         type: choice
         description: 'network used to publish contracts'
-        default: testnet
+        default: moonbase
         required: true
         options: 
-        - testnet
-        - moonbase
+          - moonbase
+          - testnet
 
 jobs:
   Upgrade-Contracts:

--- a/scripts/config/startup.json
+++ b/scripts/config/startup.json
@@ -1,7 +1,7 @@
 {
     "setupConfig": {
-        "startTime": 1665503050,
-        "endTime": 1668180003,
+        "startTime": 1683147171,
+        "endTime": 1684147171,
         "airdrops": [
             "0xEEd36C3DFEefB2D45372d72337CC48Bc97D119d4",
             "0x592C6A31df20DD24a7d33f5fe526730358337189",


### PR DESCRIPTION
## Changes:

- [x] Use moonbase config as default for `deploy` and `upgrade` contracts