### PR TITLE
Cleanup PlanManager contract

### DIFF
--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -35,7 +35,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
     /// @notice The id for next plan template
     uint256 public nextTemplateId;
 
-    /// @notice The id for next plan
+    /// @notice The id for next plan, start from 1, PurchaseOfferMarket will use 0.
     uint256 public nextPlanId;
 
     /// @notice TemplateId => Template
@@ -72,6 +72,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
 
         settings = _settings;
         limit = 5;
+        nextPlanId = 1;
     }
 
     /**

--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -163,16 +163,22 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
      * @notice Allow Consumer to accept a plan created by an indexer.
      * Consumer transfer token to ServiceAgreementRegistry contract and a service agreement will be created when they accept the plan.
      * @param planId plan Id to accept
+     * @param deploymentId project deployment Id
      */
-    function acceptPlan(uint256 planId) external {
+    function acceptPlan(uint256 planId, bytes32 deploymentId) external {
         Plan memory plan = plans[planId];
         require(plan.active, 'Inactive plan');
+        if (plan.deploymentId != bytes32(0)) {
+            require(plan.deploymentId == deploymentId, 'Deployment not match');
+        } else {
+            require(deploymentId != bytes32(0), 'Invalid deploymentId');
+        }
 
         // create closed service agreement contract
         ClosedServiceAgreementInfo memory agreement = ClosedServiceAgreementInfo(
             msg.sender,
             plan.indexer,
-            plan.deploymentId,
+            deploymentId,
             plan.price,
             block.timestamp,
             templates[plan.templateId].period,

--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -25,211 +25,162 @@ import './interfaces/IPlanManager.sol';
  * for Indexer to create the Plan.
  */
 contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
-    /**
-     * @notice Plan is created by an Indexer,  a service agreement will be created once a consumer accept a plan.
-     */
-    struct Plan {
-        uint256 price;
-        uint256 planTemplateId;
-        bytes32 deploymentId;
-        bool active;
-    }
-
-    /**
-     * @notice PlanTemplate is created and maintained by the owner, the owner provides a set of PlanTemplates for indexers to choose. For Indexer and Consumer to create the Plan and Purchase Offer.
-     */
-    struct PlanTemplate {
-        uint256 period;
-        uint256 dailyReqCap;
-        uint256 rateLimit;
-        bytes32 metadata;
-        bool active;
-    }
-
     /// @dev ### STATES
     /// @notice ISettings contract which stores SubQuery network contracts address
     ISettings public settings;
-    /// @notice Number of planTemplate
-    uint256 public planTemplateIds;
-    /// @notice planTemplateId => planTemplate
-    mapping(uint256 => PlanTemplate) public planTemplates;
-    /// @notice indexer => index
-    mapping(address => uint256) public nextPlanId;
-    /// @notice indexer => index => plan
-    mapping(address => mapping(uint256 => Plan)) public plans;
-    /// @notice indexer => deploymentId => planIds
-    mapping(address => mapping(bytes32 => uint256[])) public planIds;
-    /// @notice the limit of the plan that Indexer can create
-    uint16 public indexerPlanLimit;
 
+    /// @notice the limit of the plan that Indexer can create
+    uint256 public limit;
+
+    /// @notice The id for next plan template
+    uint256 public nextTemplateId;
+
+    /// @notice The id for next plan
+    uint256 public nextPlanId;
+
+    /// @notice TemplateId => Template
+    mapping(uint256 => PlanTemplate) private templates;
+
+    /// @notice PlanId => Plan
+    mapping(uint256 => Plan) private plans;
+
+    /// @notice indexer => deploymentId => already plan number
+    mapping(address => mapping(bytes32 => uint256)) private limits;
 
     /// @dev ### EVENTS
     /// @notice Emitted when owner create a PlanTemplate.
-    event PlanTemplateCreated(uint256 indexed planTemplateId);
+    event PlanTemplateCreated(uint256 indexed templateId);
+
     /// @notice Emitted when owner change the Metadata of a PlanTemplate.
-    event PlanTemplateMetadataChanged(uint256 indexed planTemplateId, bytes32 metadata);
+    event PlanTemplateMetadataChanged(uint256 indexed templateId, bytes32 metadata);
+
     /// @notice Emitted when owner change the status of a PlanTemplate. active or not
-    event PlanTemplateStatusChanged(uint256 indexed planTemplateId, bool active);
+    event PlanTemplateStatusChanged(uint256 indexed templateId, bool active);
+
     /// @notice Emitted when Indexer create a Plan.
-    event PlanCreated(
-        address indexed creator,
-        bytes32 indexed deploymentId,
-        uint256 planTemplateId,
-        uint256 planId,
-        uint256 price
-    );
+    event PlanCreated(uint256 indexed planId, address creator, bytes32 deploymentId, uint256 planTemplateId, uint256 price);
+
     /// @notice Emitted when Indexer remove a Plan.
-    event PlanRemoved(address indexed source, uint256 id, bytes32 deploymentId);
+    event PlanRemoved(uint256 indexed planId);
 
     /**
      * @dev ### FUNCTIONS
-     * @notice Initialize this contract to set the indexerPlanLimit be 5 which any indexer can create 5 plans.
+     * @notice Initialize this contract to set the limit be 5 which any indexer can create 5 plans.
      */
     function initialize(ISettings _settings) external initializer {
         __Ownable_init();
 
         settings = _settings;
-        indexerPlanLimit = 5;
+        limit = 5;
     }
 
     /**
      * @notice Set the indexer plan limit.
-     * @param _indexerPlanLimit indexerPlanLimit to set
+     * @param _limit limit to set
      */
-    function setIndexerPlanLimit(uint16 _indexerPlanLimit) external onlyOwner {
-        indexerPlanLimit = _indexerPlanLimit;
+    function setIndexerPlanLimit(uint256 _limit) external onlyOwner {
+        limit = _limit;
     }
 
     /**
      * @notice Allow admin to create a PlanTemplate.
-     * @param _period plan period
-     * @param _dailyReqCap daily request limit
-     * @param _rateLimit request rate limit
-     * @param _metadata plan metadata
+     * @param period plan period
+     * @param dailyReqCap daily request limit
+     * @param rateLimit request rate limit
+     * @param metadata plan metadata
      */
-    function createPlanTemplate(
-        uint256 _period,
-        uint256 _dailyReqCap,
-        uint256 _rateLimit,
-        bytes32 _metadata
-    ) external onlyOwner {
-        require(_period > 0, 'Period need to be positive');
-        require(_dailyReqCap > 0, 'DailyReqCap need to be positive');
-        require(_rateLimit > 0, 'RateLimit need to be positive');
+    function createPlanTemplate(uint256 period, uint256 dailyReqCap, uint256 rateLimit, bytes32 metadata) external onlyOwner {
+        require(period > 0, 'Period need to be positive');
+        require(dailyReqCap > 0, 'DailyReqCap need to be positive');
+        require(rateLimit > 0, 'RateLimit need to be positive');
 
-        planTemplates[planTemplateIds] = PlanTemplate(_period, _dailyReqCap, _rateLimit, _metadata, true);
+        templates[nextTemplateId] = PlanTemplate(period, dailyReqCap, rateLimit, metadata, true);
 
-        emit PlanTemplateCreated(planTemplateIds);
-
-        planTemplateIds++;
+        emit PlanTemplateCreated(nextTemplateId);
+        nextTemplateId++;
     }
 
     /**
      * @notice Allow admin to update the Metadata of a PlanTemplate.
-     * @param _planTemplateId plan template id
-     * @param _metadata metadata to update
+     * @param templateId plan template id
+     * @param metadata metadata to update
      */
-    function updatePlanTemplateMetadata(uint256 _planTemplateId, bytes32 _metadata) external onlyOwner {
-        require(planTemplates[_planTemplateId].period > 0, 'Plan template not existing');
+    function updatePlanTemplateMetadata(uint256 templateId, bytes32 metadata) external onlyOwner {
+        require(templates[templateId].period > 0, 'Plan template not existing');
 
-        planTemplates[_planTemplateId].metadata = _metadata;
+        templates[templateId].metadata = metadata;
 
-        emit PlanTemplateMetadataChanged(_planTemplateId, _metadata);
+        emit PlanTemplateMetadataChanged(templateId, metadata);
     }
 
     /**
      * @notice Allow Owner to update the status of a PlanTemplate.
-     * @param _planTemplateId plan template id
-     * @param _active plan template active or not
+     * @param templateId plan template id
+     * @param active plan template active or not
      */
-    function updatePlanTemplateStatus(uint256 _planTemplateId, bool _active) external onlyOwner {
-        require(planTemplates[_planTemplateId].period > 0, 'Plan template not existing');
+    function updatePlanTemplateStatus(uint256 templateId, bool active) external onlyOwner {
+        require(templates[templateId].period > 0, 'Plan template not existing');
 
-        planTemplates[_planTemplateId].active = _active;
+        templates[templateId].active = active;
 
-        emit PlanTemplateStatusChanged(_planTemplateId, _active);
+        emit PlanTemplateStatusChanged(templateId, active);
     }
 
     /**
      * @notice Allow Indexer to create a Plan basing on a specific plan template.
-     * @param _price plan price
-     * @param _planTemplateId plan template id
-     * @param _deploymentId project deployment Id on plan
+     * @param price plan price
+     * @param templateId plan template id
+     * @param deploymentId project deployment Id on plan
      */
-    function createPlan(
-        uint256 _price,
-        uint256 _planTemplateId,
-        bytes32 _deploymentId
-    ) external {
-        require(_price > 0, 'Price need to be positive');
-        require(planTemplates[_planTemplateId].active, 'Inactive plan template');
-        require(planIds[msg.sender][_deploymentId].length < indexerPlanLimit, 'Indexer plan limitation reached');
+    function createPlan(uint256 price, uint256 templateId, bytes32 deploymentId) external {
+        require(price > 0, 'Price need to be positive');
+        require(templates[templateId].active, 'Inactive plan template');
+        require(limits[msg.sender][deploymentId] < limit, 'Indexer plan limitation reached');
 
-        nextPlanId[msg.sender]++;
-        plans[msg.sender][nextPlanId[msg.sender]] = Plan(_price, _planTemplateId, _deploymentId, true);
-        planIds[msg.sender][_deploymentId].push(nextPlanId[msg.sender]);
+        plans[nextPlanId] = Plan(msg.sender, price, templateId, deploymentId, true);
+        limits[msg.sender][deploymentId] += 1;
 
-        emit PlanCreated(msg.sender, _deploymentId, _planTemplateId, nextPlanId[msg.sender], _price);
+        emit PlanCreated(nextPlanId, msg.sender, deploymentId, templateId, price);
+        nextPlanId++;
     }
 
     /**
      * @notice Allow Indexer to remove actived Plan.
-     * @param _planId Plan id to remove
+     * @param planId Plan id to remove
      */
-    function removePlan(uint256 _planId) external {
-        require(plans[msg.sender][_planId].active, 'Inactive plan can not be removed');
+    function removePlan(uint256 planId) external {
+        require(plans[planId].indexer == msg.sender, 'Missing plan');
 
-        bytes32 deploymentId = plans[msg.sender][_planId].deploymentId;
+        bytes32 deploymentId = plans[planId].deploymentId;
+        limits[msg.sender][deploymentId] -= 1;
+        delete plans[planId];
 
-        // remove _planId from planIds
-        uint256[] memory ids = planIds[msg.sender][deploymentId];
-        delete planIds[msg.sender][deploymentId];
-        for (uint256 i; i < ids.length; i++) {
-            if (_planId != ids[i]) {
-                planIds[msg.sender][deploymentId].push(ids[i]);
-            }
-        }
-
-        delete plans[msg.sender][_planId];
-
-        emit PlanRemoved(msg.sender, _planId, deploymentId);
+        emit PlanRemoved(planId);
     }
 
     /**
-     * @notice Allow Consumer to accept a plan created by an indexer. Consumer transfer token to ServiceAgreementRegistry contract and a service agreement will be created when they accept the plan.
-     * @param _indexer indexer address
-     * @param _deploymentId deployment Id
-     * @param _planId plan Id to accept
+     * @notice Allow Consumer to accept a plan created by an indexer.
+     * Consumer transfer token to ServiceAgreementRegistry contract and a service agreement will be created when they accept the plan.
+     * @param planId plan Id to accept
      */
-    function acceptPlan(
-        address _indexer,
-        bytes32 _deploymentId,
-        uint256 _planId
-    ) external {
-        Plan memory plan = plans[_indexer][_planId];
+    function acceptPlan(uint256 planId) external {
+        Plan memory plan = plans[planId];
         require(plan.active, 'Inactive plan');
-        require(_deploymentId != bytes32(0), 'DeploymentId can not be empty');
-        require(
-            plan.deploymentId == ((planIds[_indexer][_deploymentId].length == 0) ? bytes32(0) : _deploymentId),
-            'Plan not match with the deployment'
-        );
 
         // create closed service agreement contract
         ClosedServiceAgreementInfo memory agreement = ClosedServiceAgreementInfo(
             msg.sender,
-            _indexer,
-            _deploymentId,
+            plan.indexer,
+            plan.deploymentId,
             plan.price,
             block.timestamp,
-            planTemplates[plan.planTemplateId].period,
-            _planId,
-            plan.planTemplateId
+            templates[plan.templateId].period,
+            planId,
+            plan.templateId
         );
+
         // deposit SQToken into serviceAgreementRegistry contract
-        require(
-            IERC20(settings.getSQToken()).transferFrom(msg.sender, settings.getServiceAgreementRegistry(), plan.price),
-            'transfer fail'
-        );
+        IERC20(settings.getSQToken()).transferFrom(msg.sender, settings.getServiceAgreementRegistry(), plan.price);
 
         // register the agreement to service agreement registry contract
         IServiceAgreementRegistry registry = IServiceAgreementRegistry(settings.getServiceAgreementRegistry());
@@ -238,59 +189,18 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
     }
 
     /**
-     * @notice Get all plan templates
-     */
-    function templates() external view returns (PlanTemplate[] memory) {
-        PlanTemplate[] memory _templates = new PlanTemplate[](planTemplateIds);
-        for (uint256 i = 0; i < planTemplateIds; i++) {
-            _templates[i] = planTemplates[i];
-        }
-
-        return _templates;
-    }
-
-    /**
      * @notice Get a specific plan
-     * @param indexer indexer address
      * @param planId plan id
      */
-    function getPlan(address indexer, uint256 planId)
-        external
-        view
-        returns (
-            uint256 price,
-            uint256 planTemplateId,
-            bytes32 deploymentId,
-            bool active
-        )
-    {
-        Plan memory plan = plans[indexer][planId];
-        price = plan.price;
-        planTemplateId = plan.planTemplateId;
-        deploymentId = plan.deploymentId;
-        active = plan.active;
+    function getPlan(uint256 planId) external view returns (Plan memory) {
+        return plans[planId];
     }
 
     /**
      * @notice Get a specific plan templates
-     * @param planTemplateId plan template id
+     * @param templateId plan template id
      */
-    function getPlanTemplate(uint256 planTemplateId)
-        external
-        view
-        returns (
-            uint256 period,
-            uint256 dailyReqCap,
-            uint256 rateLimit,
-            bytes32 metadata,
-            bool active
-        )
-    {
-        PlanTemplate memory planTemplate = planTemplates[planTemplateId];
-        period = planTemplate.period;
-        dailyReqCap = planTemplate.dailyReqCap;
-        rateLimit = planTemplate.rateLimit;
-        metadata = planTemplate.metadata;
-        active = planTemplate.active;
+    function getPlanTemplate(uint256 templateId) external view returns (PlanTemplate memory) {
+        return templates[templateId];
     }
 }

--- a/contracts/PurchaseOfferMarket.sol
+++ b/contracts/PurchaseOfferMarket.sol
@@ -161,8 +161,8 @@ contract PurchaseOfferMarket is Initializable, OwnableUpgradeable, IPurchaseOffe
         require(_deposit > 0, 'should deposit positive amount');
         require(_limit > 0, 'should limit positive amount');
         IPlanManager planManager = IPlanManager(settings.getPlanManager());
-        (, , , , bool active) = planManager.getPlanTemplate(_planTemplateId);
-        require(active, 'PlanTemplate inactive');
+        PlanTemplate memory template = planManager.getPlanTemplate(_planTemplateId);
+        require(template.active, 'PlanTemplate inactive');
 
         offers[numOffers] = PurchaseOffer(
             _deposit,
@@ -253,7 +253,7 @@ contract PurchaseOfferMarket is Initializable, OwnableUpgradeable, IPurchaseOffe
         offerMmrRoot[_offerId][msg.sender] = _mmrRoot;
 
         IPlanManager planManager = IPlanManager(settings.getPlanManager());
-        (uint256 period, , , , ) = planManager.getPlanTemplate(offer.planTemplateId);
+        PlanTemplate memory template = planManager.getPlanTemplate(offer.planTemplateId);
         // create closed service agreement contract
         ClosedServiceAgreementInfo memory agreement = ClosedServiceAgreementInfo(
             offer.consumer,
@@ -261,7 +261,7 @@ contract PurchaseOfferMarket is Initializable, OwnableUpgradeable, IPurchaseOffe
             offer.deploymentId,
             offer.deposit,
             block.timestamp,
-            period,
+            template.period,
             0,
             offer.planTemplateId
         );

--- a/contracts/ServiceAgreementRegistry.sol
+++ b/contracts/ServiceAgreementRegistry.sol
@@ -233,8 +233,8 @@ contract ServiceAgreementRegistry is Initializable, OwnableUpgradeable, IService
         require(agreement.planId != 0, 'Agreement cannot renew without planId');
 
         IPlanManager planManager = IPlanManager(settings.getPlanManager());
-        (, , , bool active) = planManager.getPlan(agreement.indexer, agreement.planId);
-        require(active, 'Plan is inactive');
+        Plan memory plan = planManager.getPlan(agreement.planId);
+        require(plan.active, 'Plan is inactive');
         require((agreement.startDate + agreement.period) > block.timestamp, 'Agreement ended');
 
         // create closed service agreement

--- a/contracts/ServiceAgreementRegistry.sol
+++ b/contracts/ServiceAgreementRegistry.sol
@@ -230,7 +230,6 @@ contract ServiceAgreementRegistry is Initializable, OwnableUpgradeable, IService
         ClosedServiceAgreementInfo memory agreement = closedServiceAgreements[agreementId];
         require(msg.sender == agreement.consumer, 'Sender is not the consumer');
         require(agreement.startDate < block.timestamp, 'Cannot renew upcoming agreement');
-        require(agreement.planId != 0, 'Agreement cannot renew without planId');
 
         IPlanManager planManager = IPlanManager(settings.getPlanManager());
         Plan memory plan = planManager.getPlan(agreement.planId);

--- a/contracts/interfaces/IPlanManager.sol
+++ b/contracts/interfaces/IPlanManager.sol
@@ -3,25 +3,33 @@
 
 pragma solidity 0.8.15;
 
-interface IPlanManager {
-    function getPlan(address indexer, uint256 planId)
-        external
-        view
-        returns (
-            uint256 price,
-            uint256 planTemplateId,
-            bytes32 deploymentId,
-            bool active
-        );
+/**
+ * @notice Plan is created by an Indexer,
+ * a service agreement will be created once a consumer accept a plan.
+ */
+struct Plan {
+    address indexer;
+    uint256 price;
+    uint256 templateId;
+    bytes32 deploymentId;
+    bool active;
+}
 
-    function getPlanTemplate(uint256 planTemplateId)
-        external
-        view
-        returns (
-            uint256 period,
-            uint256 dailyReqCap,
-            uint256 rateLimit,
-            bytes32 metadata,
-            bool active
-        );
+/**
+ * @notice PlanTemplate is created and maintained by the owner,
+ * the owner provides a set of PlanTemplates for indexers to choose.
+ * For Indexer and Consumer to create the Plan and Purchase Offer.
+ */
+struct PlanTemplate {
+    uint256 period;
+    uint256 dailyReqCap;
+    uint256 rateLimit;
+    bytes32 metadata;
+    bool active;
+}
+
+interface IPlanManager {
+    function getPlan(uint256 planId) external view returns (Plan memory);
+
+    function getPlanTemplate(uint256 templateId) external view returns (PlanTemplate memory);
 }

--- a/test/PermissionedExchange.test.ts
+++ b/test/PermissionedExchange.test.ts
@@ -115,7 +115,7 @@ describe('PermissionedExchange Contract', () => {
             // default plan -> planId: 1
             await planManager.connect(indexer).createPlan(etherParse('10'), 0, DEPLOYMENT_ID);
             await sqToken.connect(consumer).increaseAllowance(serviceAgreementRegistry.address, etherParse('50'));
-            await planManager.connect(consumer).acceptPlan(1);
+            await planManager.connect(consumer).acceptPlan(1, DEPLOYMENT_ID);
         });
 
         it('claimed reward should add to quota', async () => {

--- a/test/PermissionedExchange.test.ts
+++ b/test/PermissionedExchange.test.ts
@@ -113,7 +113,7 @@ describe('PermissionedExchange Contract', () => {
             // create plan template
             await planManager.createPlanTemplate(time.duration.days(3).toString(), 1000, 100, METADATA_HASH);
             // default plan -> planId: 1
-            await planManager.connect(indexer).createPlan(etherParse('10'), 0, constants.ZERO_BYTES32);
+            await planManager.connect(indexer).createPlan(etherParse('10'), 0, DEPLOYMENT_ID);
             await sqToken.connect(consumer).increaseAllowance(serviceAgreementRegistry.address, etherParse('50'));
             await planManager.connect(consumer).acceptPlan(1);
         });

--- a/test/PermissionedExchange.test.ts
+++ b/test/PermissionedExchange.test.ts
@@ -112,10 +112,10 @@ describe('PermissionedExchange Contract', () => {
             await queryRegistry.connect(indexer).updateIndexingStatusToReady(DEPLOYMENT_ID);
             // create plan template
             await planManager.createPlanTemplate(time.duration.days(3).toString(), 1000, 100, METADATA_HASH);
-            // default plan -> planId: 0
+            // default plan -> planId: 1
             await planManager.connect(indexer).createPlan(etherParse('10'), 0, constants.ZERO_BYTES32);
             await sqToken.connect(consumer).increaseAllowance(serviceAgreementRegistry.address, etherParse('50'));
-            await planManager.connect(consumer).acceptPlan(indexer.address, DEPLOYMENT_ID, 1);
+            await planManager.connect(consumer).acceptPlan(1);
         });
 
         it('claimed reward should add to quota', async () => {

--- a/test/PermissionedExchange.test.ts
+++ b/test/PermissionedExchange.test.ts
@@ -113,7 +113,7 @@ describe('PermissionedExchange Contract', () => {
             // create plan template
             await planManager.createPlanTemplate(time.duration.days(3).toString(), 1000, 100, METADATA_HASH);
             // default plan -> planId: 1
-            await planManager.connect(indexer).createPlan(etherParse('10'), 0, DEPLOYMENT_ID);
+            await planManager.connect(indexer).createPlan(etherParse('10'), 0, constants.ZERO_BYTES32);
             await sqToken.connect(consumer).increaseAllowance(serviceAgreementRegistry.address, etherParse('50'));
             await planManager.connect(consumer).acceptPlan(1, DEPLOYMENT_ID);
         });

--- a/test/PlanManager.test.ts
+++ b/test/PlanManager.test.ts
@@ -204,7 +204,7 @@ describe('PlanManger Contract', () => {
             // create plan template
             await planManager.createPlanTemplate(time.duration.days(3).toString(), 1000, 100, METADATA_HASH);
             // default plan -> planId: 1
-            await planManager.createPlan(etherParse('2'), 0, DEPLOYMENT_ID); // plan id = 1;
+            await planManager.createPlan(etherParse('2'), 0, constants.ZERO_BYTES32); // plan id = 1;
         });
 
         const checkAcceptPlan = async (planId: number, deploymentId: string) => {
@@ -264,12 +264,11 @@ describe('PlanManger Contract', () => {
         });
 
         it('accept plan with specific deployment plan should work', async () => {
-            await planManager.createPlan(etherParse('2'), 0, constants.ZERO_BYTES32);
             const newDeployment = deploymentIds[1];
 
             // query not acitve should not work
             await token.connect(consumer).approve(serviceAgreementRegistry.address, etherParse('2'));
-            await expect(planManager.connect(consumer).acceptPlan(2, newDeployment)).to.be.revertedWith(
+            await expect(planManager.connect(consumer).acceptPlan(1, newDeployment)).to.be.revertedWith(
                 'Indexing service is not available'
             );
 
@@ -278,7 +277,7 @@ describe('PlanManger Contract', () => {
             await queryRegistry.startIndexing(newDeployment);
             await queryRegistry.updateIndexingStatusToReady(newDeployment);
 
-            await checkAcceptPlan(2, newDeployment);
+            await checkAcceptPlan(1, newDeployment);
         });
     });
 });

--- a/test/Startup.test.ts
+++ b/test/Startup.test.ts
@@ -40,8 +40,8 @@ describe('startup script', () => {
             expect((await sdk.airdropper.roundRecord(0)).roundDeadline).to.equal(config.setupConfig.endTime);
             expect((await sdk.airdropper.roundRecord(0)).unclaimedAmount).to.equal(2100);
 
-            const { setupConfig } = config;
-            const { airdrops, amounts } = setupConfig;
+            const {setupConfig} = config;
+            const {airdrops, amounts} = setupConfig;
 
             for (const [i, airdrop] of airdrops.entries()) {
                 expect(await sdk.airdropper.airdropRecord(airdrop, 0)).to.equal(amounts[i]);
@@ -49,17 +49,17 @@ describe('startup script', () => {
         });
 
         it('planTemplate setups should work', async () => {
-            expect(await sdk.planManager.planTemplateIds()).to.be.equal(5);
-            const { setupConfig } = config;
+            expect(await sdk.planManager.nextTemplateId()).to.be.equal(5);
+            const {setupConfig} = config;
 
             for (const [i, p] of setupConfig.planTemplates.entries()) {
-                expect((await sdk.planManager.planTemplates(i)).period).to.be.equal(p.period);
+                expect((await sdk.planManager.getPlanTemplate(i)).period).to.be.equal(p.period);
             }
         });
 
         it('dictionaries should be created', async () => {
-            const { dictionaries } = config;
-            for (const [i, d] of dictionaries.entries()){
+            const {dictionaries} = config;
+            for (const [i, d] of dictionaries.entries()) {
                 const info = await sdk.queryRegistry.queryInfos(i);
                 expect(info.latestDeploymentId).to.be.equal(cidToBytes32(d.deploymentId));
                 expect(info.latestVersion).to.be.equal(cidToBytes32(d.versionCid));

--- a/test/fixtureLoader.ts
+++ b/test/fixtureLoader.ts
@@ -175,7 +175,12 @@ export const loaders = {
         {ipfs, sdk, rootAccount}: Context
     ) {
         console.log(`PlanTemplate Start`);
-        const templates = await sdk.planManager.templates();
+        const next = await sdk.planManager.nextTemplateId();
+        let templates;
+        for (let i = 0; i < next.toNumber(); i++) {
+            const template = await sdk.planManager.getPlanTemplate(i);
+            templates.push(template);
+        }
         console.log(templates);
         const match = templates.findIndex(
             (tpl) => tpl.dailyReqCap.eq(dailyReqCap) && tpl.period.eq(period) && tpl.rateLimit.eq(rateLimit)

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -4,14 +4,7 @@ import {ServiceAgreementRegistry} from './../src/typechain/ServiceAgreementRegis
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import {MockProvider} from 'ethereum-waffle';
-import {
-    BaseContract,
-    BigNumber,
-    Wallet,
-    ContractTransaction,
-    utils,
-    Contract,
-} from "ethers";
+import {BaseContract, BigNumber, Wallet, ContractTransaction, utils, Contract} from 'ethers';
 import {IndexerRegistry, EraManager, PlanManager} from '../src';
 import {METADATA_HASH, VERSION} from './constants';
 const {constants, time} = require('@openzeppelin/test-helpers');
@@ -111,7 +104,7 @@ export async function acceptPlan(
     await planManager.createPlanTemplate(time.duration.days(period).toString(), 1000, 100, METADATA_HASH);
     await planManager.connect(indexer).createPlan(value, 0, DEPLOYMENT_ID);
 
-    await planManager.connect(consumer).acceptPlan(indexer.address, DEPLOYMENT_ID, 1);
+    await planManager.connect(consumer).acceptPlan(1);
 }
 
 export function etherParse(etherNum: string) {
@@ -124,8 +117,5 @@ export async function eventFrom(tx: ContractTransaction, contract: BaseContract,
     const evt = receipt.events.find((log) => log.topics[0] === utils.id(event));
 
     const eventName = event.split('(')[0];
-    return contract.interface.decodeEventLog(
-        contract.interface.getEvent(eventName),
-        evt.data
-    );
+    return contract.interface.decodeEventLog(contract.interface.getEvent(eventName), evt.data);
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -103,7 +103,7 @@ export async function acceptPlan(
 ) {
     await planManager.createPlanTemplate(time.duration.days(period).toString(), 1000, 100, METADATA_HASH);
     await planManager.connect(indexer).createPlan(value, 0, DEPLOYMENT_ID);
-    await planManager.connect(consumer).acceptPlan((await planManager.nextPlanId()).toNumber() - 1);
+    await planManager.connect(consumer).acceptPlan((await planManager.nextPlanId()).toNumber() - 1, DEPLOYMENT_ID);
 }
 
 export function etherParse(etherNum: string) {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -103,8 +103,7 @@ export async function acceptPlan(
 ) {
     await planManager.createPlanTemplate(time.duration.days(period).toString(), 1000, 100, METADATA_HASH);
     await planManager.connect(indexer).createPlan(value, 0, DEPLOYMENT_ID);
-
-    await planManager.connect(consumer).acceptPlan(1);
+    await planManager.connect(consumer).acceptPlan((await planManager.nextPlanId()).toNumber() - 1);
 }
 
 export function etherParse(etherNum: string) {

--- a/test/serviceAgreementRegistry.test.ts
+++ b/test/serviceAgreementRegistry.test.ts
@@ -407,7 +407,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('renew agreement generated from planManager should work', async () => {
-            await planManager.connect(wallet2).acceptPlan(1);
+            await planManager.connect(wallet2).acceptPlan(1, deploymentIds[0]);
             const addTable = await rewardsHelper.getRewardsAddTable(wallet1.address, 2, 10);
             const removeTable = await rewardsHelper.getRewardsRemoveTable(wallet1.address, 2, 12);
 
@@ -438,7 +438,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('Indexers should be able to trun off renew', async () => {
-            await planManager.connect(wallet2).acceptPlan(1);
+            await planManager.connect(wallet2).acceptPlan(1, deploymentIds[0]);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             expect((await planManager.getPlan(1)).active).to.be.eq(true);
@@ -451,7 +451,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('customer cannot renew expired agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(1);
+            await planManager.connect(wallet2).acceptPlan(1, deploymentIds[0]);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(20).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId)).to.be.revertedWith(
@@ -460,7 +460,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('only customer can renew agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(1);
+            await planManager.connect(wallet2).acceptPlan(1, deploymentIds[0]);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet1).renewAgreement(agreementId)).to.be.revertedWith(
@@ -469,7 +469,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('cannot renew upcoming agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(1);
+            await planManager.connect(wallet2).acceptPlan(1, deploymentIds[0]);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId);

--- a/test/serviceAgreementRegistry.test.ts
+++ b/test/serviceAgreementRegistry.test.ts
@@ -441,9 +441,9 @@ describe('Service Agreement Registry Contract', () => {
             await planManager.connect(wallet2).acceptPlan(1);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
-            expect((await planManager.getPlan(1))[3]).to.be.eq(true);
+            expect((await planManager.getPlan(1)).active).to.be.eq(true);
             await planManager.connect(wallet1).removePlan(1);
-            expect((await planManager.getPlan(1))[3]).to.be.eq(false);
+            expect((await planManager.getPlan(1)).active).to.be.eq(false);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId)).to.be.revertedWith(
                 'Plan is inactive'

--- a/test/serviceAgreementRegistry.test.ts
+++ b/test/serviceAgreementRegistry.test.ts
@@ -81,8 +81,8 @@ describe('Service Agreement Registry Contract', () => {
 
         await queryRegistry.setCreatorRestricted(false);
 
-        //period 1000 s
-        //planTemplateId: 0
+        // period 1000 s
+        // planTemplateId: 0
         await planManager.createPlanTemplate(1000, 1000, 100, METADATA_HASH);
 
         await serviceAgreementRegistry.setThreshold(allowanceMultiplerBP);
@@ -378,21 +378,22 @@ describe('Service Agreement Registry Contract', () => {
             await queryRegistry.connect(wallet1).startIndexing(deploymentIds[0]);
             await queryRegistry.connect(wallet1).updateIndexingStatusToReady(deploymentIds[0]);
 
-            //period 10 days
-            //planTemplateId: 1
+            // period 10 days
+            // planTemplateId: 1
             await planManager.createPlanTemplate(time.duration.days(10).toString(), 1000, 100, METADATA_HASH);
 
             // create purchase offer
-            //value 100*2
-            //period 10 days
-            //use planTemplateId: 1
+            // value 100*2
+            // period 10 days
+            // use planTemplateId: 1
             await purchaseOfferMarket
                 .connect(wallet2)
                 .createPurchaseOffer(deploymentIds[0], 1, 100, 2, 100, await futureTimestamp(mockProvider));
             // create plan
-            //value 100
-            //period 10 days
-            //use planTemplateId: 1
+            // value 100
+            // period 10 days
+            // use planTemplateId: 1
+            // use planId: 1
             await planManager.connect(wallet1).createPlan(100, 1, deploymentIds[0]);
         });
 
@@ -401,12 +402,12 @@ describe('Service Agreement Registry Contract', () => {
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(3).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId)).to.be.revertedWith(
-                'Agreement cannot renew without planId'
+                'Plan is inactive'
             );
         });
 
         it('renew agreement generated from planManager should work', async () => {
-            await planManager.connect(wallet2).acceptPlan(wallet1.address, deploymentIds[0], 1);
+            await planManager.connect(wallet2).acceptPlan(1);
             const addTable = await rewardsHelper.getRewardsAddTable(wallet1.address, 2, 10);
             const removeTable = await rewardsHelper.getRewardsRemoveTable(wallet1.address, 2, 12);
 
@@ -437,12 +438,12 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('Indexers should be able to trun off renew', async () => {
-            await planManager.connect(wallet2).acceptPlan(wallet1.address, deploymentIds[0], 1);
+            await planManager.connect(wallet2).acceptPlan(1);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
-            expect((await planManager.getPlan(wallet1.address, 1))[3]).to.be.eq(true);
+            expect((await planManager.getPlan(1))[3]).to.be.eq(true);
             await planManager.connect(wallet1).removePlan(1);
-            expect((await planManager.getPlan(wallet1.address, 1))[3]).to.be.eq(false);
+            expect((await planManager.getPlan(1))[3]).to.be.eq(false);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId)).to.be.revertedWith(
                 'Plan is inactive'
@@ -450,7 +451,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('customer cannot renew expired agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(wallet1.address, deploymentIds[0], 1);
+            await planManager.connect(wallet2).acceptPlan(1);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(20).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId)).to.be.revertedWith(
@@ -459,7 +460,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('only customer can renew agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(wallet1.address, deploymentIds[0], 1);
+            await planManager.connect(wallet2).acceptPlan(1);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await expect(serviceAgreementRegistry.connect(wallet1).renewAgreement(agreementId)).to.be.revertedWith(
@@ -468,7 +469,7 @@ describe('Service Agreement Registry Contract', () => {
         });
 
         it('cannot renew upcoming agreement', async () => {
-            await planManager.connect(wallet2).acceptPlan(wallet1.address, deploymentIds[0], 1);
+            await planManager.connect(wallet2).acceptPlan(1);
             const agreementId = await serviceAgreementRegistry.closedServiceAgreementIds(wallet1.address, 0);
             await timeTravel(mockProvider, time.duration.days(1).toNumber());
             await serviceAgreementRegistry.connect(wallet2).renewAgreement(agreementId);
@@ -492,10 +493,10 @@ describe('Service Agreement Registry Contract', () => {
             expect(await serviceAgreementRegistry.consumerAuthAllows(consumer.address, user_1)).to.eql(true);
             expect(await serviceAgreementRegistry.consumerAuthAllows(consumer.address, user_2)).to.eql(false);
             let tx = await serviceAgreementRegistry.connect(consumer).addUser(consumer.address, user_2);
-            let event = await eventFrom(tx, serviceAgreementRegistry, "UserAdded(address,address)");
+            let event = await eventFrom(tx, serviceAgreementRegistry, 'UserAdded(address,address)');
             expect(event.user).to.eql(user_2);
             tx = await serviceAgreementRegistry.connect(consumer).removeUser(consumer.address, user_1);
-            event = await eventFrom(tx, serviceAgreementRegistry, "UserRemoved(address,address)");
+            event = await eventFrom(tx, serviceAgreementRegistry, 'UserRemoved(address,address)');
             expect(event.user).to.eql(user_1);
             expect(await serviceAgreementRegistry.consumerAuthAllows(consumer.address, user_1)).to.eql(false);
             expect(await serviceAgreementRegistry.consumerAuthAllows(consumer.address, user_2)).to.eql(true);


### PR DESCRIPTION
cleanup the storage and functions,
contract size from 12.542 ->  10.243

CHANGELOG:
- `Plan` and `PlanTemplate` move to interface.
- `getPlan` & `getPlanTemplate` will return struct, just use the `planId` and `templateId`.
- Plan & Template will use global auto-increase id to storage. `nextPlanId` start from 1, `nextTemplateId` start from 0.
- `indexerPlanLimit ` rename to `public limit`
- `event PlanCreate` will start from `PlanId`
- `event PlanRemove` will just return `PlanId`
- `function acceptPlan` just use `PlanId`