### PR TITLE
[wip]Fix collect rewards failed due to withdraw issue

### DIFF
--- a/contracts/RewardsHelper.sol
+++ b/contracts/RewardsHelper.sol
@@ -9,6 +9,7 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import './interfaces/ISettings.sol';
 import './interfaces/IEraManager.sol';
 import './RewardsDistributer.sol';
+import './StakingManager.sol';
 import './RewardsStaking.sol';
 import './utils/MathUtil.sol';
 

--- a/contracts/RewardsHelper.sol
+++ b/contracts/RewardsHelper.sol
@@ -61,6 +61,9 @@ contract RewardsHelper is Initializable, OwnableUpgradeable {
     }
 
     function indexerCatchup(address indexer) public {
+        StakingManager stakingManager = StakingManager(settings.getStakingManager());
+        stakingManager.widthdraw(indexer);
+
         RewardsDistributer rewardsDistributer = RewardsDistributer(settings.getRewardsDistributer());
         RewardsStaking rewardsStaking = RewardsStaking(settings.getRewardsStaking());
         uint256 currentEra = IEraManager(settings.getEraManager()).eraNumber();

--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -128,22 +128,22 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
      * @dev Withdraw max 21 mature unbond requests from an indexer.
      * Each withdraw need to exceed lockPeriod.
      */
-    function widthdraw(address indexer) external {
+    function widthdraw(address account) external {
         require(!(IEraManager(settings.getEraManager()).maintenance()), 'G019');
-        require(!IDisputeManager(settings.getDisputeManager()).isOnDispute(indexer), 'G006');
+        require(!IDisputeManager(settings.getDisputeManager()).isOnDispute(account), 'G006');
 
         Staking staking = Staking(settings.getStaking());
-        uint256 withdrawingLength = staking.unbondingLength(indexer) - staking.withdrawnLength(indexer);
+        uint256 withdrawingLength = staking.unbondingLength(account) - staking.withdrawnLength(account);
         require(withdrawingLength > 0, 'S009');
 
-        uint256 latestWithdrawnLength = staking.withdrawnLength(indexer);
+        uint256 latestWithdrawnLength = staking.withdrawnLength(account);
         for (uint256 i = latestWithdrawnLength; i < latestWithdrawnLength + withdrawingLength; i++) {
-            (,,uint256 startTime) = staking.unbondingAmount(indexer, i);
+            (,,uint256 startTime) = staking.unbondingAmount(account, i);
             if (block.timestamp - startTime < staking.lockPeriod()) {
                 break;
             }
 
-            staking.withdrawARequest(indexer, i);
+            staking.withdrawARequest(account, i);
         }
     }
 

--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -128,22 +128,22 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
      * @dev Withdraw max 21 mature unbond requests from an indexer.
      * Each withdraw need to exceed lockPeriod.
      */
-    function widthdraw(address account) external {
+    function widthdraw(address source) external {
         require(!(IEraManager(settings.getEraManager()).maintenance()), 'G019');
-        require(!IDisputeManager(settings.getDisputeManager()).isOnDispute(account), 'G006');
+        require(!IDisputeManager(settings.getDisputeManager()).isOnDispute(source), 'G006');
 
         Staking staking = Staking(settings.getStaking());
-        uint256 withdrawingLength = staking.unbondingLength(account) - staking.withdrawnLength(account);
+        uint256 withdrawingLength = staking.unbondingLength(source) - staking.withdrawnLength(source);
         require(withdrawingLength > 0, 'S009');
 
-        uint256 latestWithdrawnLength = staking.withdrawnLength(account);
+        uint256 latestWithdrawnLength = staking.withdrawnLength(source);
         for (uint256 i = latestWithdrawnLength; i < latestWithdrawnLength + withdrawingLength; i++) {
-            (,,uint256 startTime) = staking.unbondingAmount(account, i);
+            (,,uint256 startTime) = staking.unbondingAmount(source, i);
             if (block.timestamp - startTime < staking.lockPeriod()) {
                 break;
             }
 
-            staking.withdrawARequest(account, i);
+            staking.withdrawARequest(source, i);
         }
     }
 

--- a/test/DisputeManager.test.ts
+++ b/test/DisputeManager.test.ts
@@ -199,10 +199,10 @@ describe('Dispute Manager Contract', () => {
             ).to.be.revertedWith('D005');
         });
 
-        it('indexer cannot widthdraw if on dispute', async () => {
+        it.only('indexer cannot widthdraw if on dispute', async () => {
             await stakingManager.connect(indexer).unstake(indexer.address, etherParse('2'));
             await expect(
-                stakingManager.connect(indexer).widthdraw()
+                stakingManager.widthdraw(indexer)
             ).to.be.revertedWith('G006');
         });
     });

--- a/test/DisputeManager.test.ts
+++ b/test/DisputeManager.test.ts
@@ -199,11 +199,9 @@ describe('Dispute Manager Contract', () => {
             ).to.be.revertedWith('D005');
         });
 
-        it.only('indexer cannot widthdraw if on dispute', async () => {
+        it('indexer cannot widthdraw if on dispute', async () => {
             await stakingManager.connect(indexer).unstake(indexer.address, etherParse('2'));
-            await expect(
-                stakingManager.widthdraw(indexer)
-            ).to.be.revertedWith('G006');
+            await expect(stakingManager.widthdraw(indexer.address)).to.be.revertedWith('G006');
         });
     });
 });

--- a/test/Maintenance.test.ts
+++ b/test/Maintenance.test.ts
@@ -194,8 +194,8 @@ describe('Maintenance Mode Test', () => {
         it('redelegate should ban in maintenance mode', async () => {
             await expect(stakingManager.connect(wallet_1).redelegate(wallet_0.address, wallet_2.address, etherParse('1'))).to.be.revertedWith('G019');
         });
-        it('widthdraw should ban in maintenance mode', async () => {
-            await expect(stakingManager.connect(wallet_1).widthdraw()).to.be.revertedWith('G019');
+        it.only('widthdraw should ban in maintenance mode', async () => {
+            await expect(stakingManager.widthdraw(wallet_1)).to.be.revertedWith('G019');
         });
         it('cancelUnbonding should ban in maintenance mode', async () => {
             await expect(stakingManager.connect(wallet_1).cancelUnbonding(0)).to.be.revertedWith('G019');

--- a/test/Maintenance.test.ts
+++ b/test/Maintenance.test.ts
@@ -194,8 +194,8 @@ describe('Maintenance Mode Test', () => {
         it('redelegate should ban in maintenance mode', async () => {
             await expect(stakingManager.connect(wallet_1).redelegate(wallet_0.address, wallet_2.address, etherParse('1'))).to.be.revertedWith('G019');
         });
-        it.only('widthdraw should ban in maintenance mode', async () => {
-            await expect(stakingManager.widthdraw(wallet_1)).to.be.revertedWith('G019');
+        it('widthdraw should ban in maintenance mode', async () => {
+            await expect(stakingManager.widthdraw(wallet_1.address)).to.be.revertedWith('G019');
         });
         it('cancelUnbonding should ban in maintenance mode', async () => {
             await expect(stakingManager.connect(wallet_1).cancelUnbonding(0)).to.be.revertedWith('G019');

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -598,8 +598,8 @@ describe('RewardsDistributer Contract', () => {
             await rewardsStaking.applyStakeChange(indexer.address, delegator.address);
             await checkValues(etherParse('2.697302697'), etherParse('9.002697302697'), 0, 0);
             // 5. indexer and delegator widthdraw, check values change
-            await stakingManager.connect(indexer).widthdraw();
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(indexer);
+            await stakingManager.widthdraw(delegator);
             await checkValues(etherParse('1001.997002697'), etherParse('10.001697302697'), 0, 0);
         });
 
@@ -634,7 +634,7 @@ describe('RewardsDistributer Contract', () => {
             ).to.be.revertedWith('RS001');
         });
 
-        it('indexer without delegators can reregister', async () => {
+        it.only('indexer without delegators can reregister', async () => {
             // 1. start new era -> indexer `collectAndDistributeRewards` -> `applyStakeChange`: era[n+1]
             await startNewEra(mockProvider, eraManager);
             await rewardsDistributor.collectAndDistributeRewards(indexer.address);
@@ -648,14 +648,14 @@ describe('RewardsDistributer Contract', () => {
             // 4. check totalStakingAmount equal 0, era reward equal 0
             await checkValues(etherParse('2.697302697'), etherParse('9.002697302697'), 0, 0);
             // 5. indexer register successfully
-            await stakingManager.connect(indexer).widthdraw();
+            await stakingManager.widthdraw(indexer);
             await token.connect(indexer).increaseAllowance(staking.address, etherParse('1000'));
             await indexerRegistry
                 .connect(indexer)
                 .registerIndexer(etherParse('1000'), METADATA_HASH, 100, {gasLimit: '2000000'});
         });
 
-        it('reward distribution should work after indexer reregister immediately', async () => {
+        it.only('reward distribution should work after indexer reregister immediately', async () => {
             // 1. delegator undelegate all the tokens
             await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('1'));
             // 2. start new era -> indexer `collectAndDistributeRewards` -> `applyStakeChange | delegator -> `applyStakeChange`
@@ -663,8 +663,8 @@ describe('RewardsDistributer Contract', () => {
             await rewardsDistributor.collectAndDistributeRewards(indexer.address);
             await rewardsStaking.applyStakeChange(indexer.address, indexer.address);
             await rewardsStaking.applyStakeChange(indexer.address, delegator.address);
-            await stakingManager.connect(indexer).widthdraw();
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(indexer);
+            await stakingManager.widthdraw(delegator);
             // 3. indexer reregister -> add previous delegator and a new delegator
             await token.connect(indexer).increaseAllowance(staking.address, etherParse('1000'));
             await indexerRegistry
@@ -706,7 +706,7 @@ describe('RewardsDistributer Contract', () => {
             await checkValues(etherParse('4.996702697'), etherParse('9.001697302697'), etherParse('1002'), 0);
         });
 
-        it('reward distribution should work after indexer reregister few more ears later', async () => {
+        it.only('reward distribution should work after indexer reregister few more ears later', async () => {
             // 1. delegator undelegate all the tokens
             await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('1'));
             // 2. start new era -> indexer `collectAndDistributeRewards` -> `applyStakeChange | delegator -> `applyStakeChange`
@@ -714,8 +714,8 @@ describe('RewardsDistributer Contract', () => {
             await rewardsDistributor.collectAndDistributeRewards(indexer.address);
             await rewardsStaking.applyStakeChange(indexer.address, indexer.address);
             await rewardsStaking.applyStakeChange(indexer.address, delegator.address);
-            await stakingManager.connect(indexer).widthdraw();
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(indexer);
+            await stakingManager.widthdraw(delegator);
             //after few more eras
             await startNewEra(mockProvider, eraManager);
             await startNewEra(mockProvider, eraManager);

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -332,7 +332,7 @@ describe('Staking Contract', () => {
         });
     });
 
-    describe('Request cancel unbond', () => {
+    describe.only('Request cancel unbond', () => {
         beforeEach(async () => {
             await stakingManager.connect(delegator).delegate(indexer.address, etherParse('2'));
             await stakingManager.connect(indexer).stake(indexer.address, etherParse('2'));
@@ -351,7 +351,7 @@ describe('Staking Contract', () => {
             expect((await staking.unbondingAmount(delegator.address, 0)).amount).to.equal(etherParse('0'));
             expect(await stakingManager.getAfterDelegationAmount(delegator.address, indexer.address)).to.equal(delegateAmount);
             await timeTravel(mockProvider, 1000);
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             expect(await token.balanceOf(delegator.address)).to.equal(delegatorBalance);
             expect(await token.balanceOf(staking.address)).to.equal(contractBalance);
         });
@@ -370,7 +370,7 @@ describe('Staking Contract', () => {
         it('cancel withdrawed unbonding should fail', async () => {
             await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('1'));
             await timeTravel(mockProvider, 60 * 60 * 24 * 10);
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             await expect(stakingManager.connect(delegator).cancelUnbonding(0)).to.be.revertedWith('S007');
         });
 
@@ -411,7 +411,7 @@ describe('Staking Contract', () => {
             // withdraw an undelegate
             const unbondingAmount = await staking.unbondingAmount(delegator.address, 0);
             const {availableAmount} = await availableWidthdraw(unbondingAmount.amount);
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
 
             // check balances
             expect(await token.balanceOf(delegator.address)).to.equal(delegatorBalance.add(availableAmount));
@@ -438,14 +438,14 @@ describe('Staking Contract', () => {
             await checkUnbondingChanges(delegatorBalance, 5, 0);
 
             // widthdraw the fist 3 requests
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             const {availableAmount} = await availableWidthdraw(BigNumber.from(etherParse('0.1')));
             delegatorBalance = delegatorBalance.add(availableAmount.mul(3));
             await checkUnbondingChanges(delegatorBalance, 5, 3);
 
             // widthdraw the other 2 requests
             await timeTravel(mockProvider, 1000);
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             delegatorBalance = delegatorBalance.add(availableAmount.mul(2));
             await checkUnbondingChanges(delegatorBalance, 5, 5);
         });
@@ -467,7 +467,7 @@ describe('Staking Contract', () => {
             await checkUnbondingChanges(delegatorBalance, 15, 0);
 
             // first withdraw only claim the first 10 requests
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             // check balance and unbonding storage
             const {availableAmount} = await availableWidthdraw(BigNumber.from(etherParse('0.1')));
             delegatorBalance = delegatorBalance.add(availableAmount.mul(12));
@@ -475,14 +475,14 @@ describe('Staking Contract', () => {
 
             // make the next 3 undelegate requests ready to withdraw
             await timeTravel(mockProvider, 1000);
-            await stakingManager.connect(delegator).widthdraw();
+            await stakingManager.widthdraw(delegator);
             delegatorBalance = delegatorBalance.add(availableAmount.mul(3));
             await checkUnbondingChanges(delegatorBalance, 15, 15);
         });
 
         it('withdraw an unbond with invalid status should fail', async () => {
             // no unbonding requests for withdrawing
-            await expect(stakingManager.connect(delegator).widthdraw()).to.be.revertedWith('S009');
+            await expect(stakingManager.widthdraw(delegator)).to.be.revertedWith('S009');
         });
     });
 

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -332,7 +332,7 @@ describe('Staking Contract', () => {
         });
     });
 
-    describe.only('Request cancel unbond', () => {
+    describe('Request cancel unbond', () => {
         beforeEach(async () => {
             await stakingManager.connect(delegator).delegate(indexer.address, etherParse('2'));
             await stakingManager.connect(indexer).stake(indexer.address, etherParse('2'));
@@ -351,7 +351,7 @@ describe('Staking Contract', () => {
             expect((await staking.unbondingAmount(delegator.address, 0)).amount).to.equal(etherParse('0'));
             expect(await stakingManager.getAfterDelegationAmount(delegator.address, indexer.address)).to.equal(delegateAmount);
             await timeTravel(mockProvider, 1000);
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             expect(await token.balanceOf(delegator.address)).to.equal(delegatorBalance);
             expect(await token.balanceOf(staking.address)).to.equal(contractBalance);
         });
@@ -370,7 +370,7 @@ describe('Staking Contract', () => {
         it('cancel withdrawed unbonding should fail', async () => {
             await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('1'));
             await timeTravel(mockProvider, 60 * 60 * 24 * 10);
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             await expect(stakingManager.connect(delegator).cancelUnbonding(0)).to.be.revertedWith('S007');
         });
 
@@ -411,7 +411,7 @@ describe('Staking Contract', () => {
             // withdraw an undelegate
             const unbondingAmount = await staking.unbondingAmount(delegator.address, 0);
             const {availableAmount} = await availableWidthdraw(unbondingAmount.amount);
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
 
             // check balances
             expect(await token.balanceOf(delegator.address)).to.equal(delegatorBalance.add(availableAmount));
@@ -438,14 +438,14 @@ describe('Staking Contract', () => {
             await checkUnbondingChanges(delegatorBalance, 5, 0);
 
             // widthdraw the fist 3 requests
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             const {availableAmount} = await availableWidthdraw(BigNumber.from(etherParse('0.1')));
             delegatorBalance = delegatorBalance.add(availableAmount.mul(3));
             await checkUnbondingChanges(delegatorBalance, 5, 3);
 
             // widthdraw the other 2 requests
             await timeTravel(mockProvider, 1000);
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             delegatorBalance = delegatorBalance.add(availableAmount.mul(2));
             await checkUnbondingChanges(delegatorBalance, 5, 5);
         });
@@ -467,7 +467,7 @@ describe('Staking Contract', () => {
             await checkUnbondingChanges(delegatorBalance, 15, 0);
 
             // first withdraw only claim the first 10 requests
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             // check balance and unbonding storage
             const {availableAmount} = await availableWidthdraw(BigNumber.from(etherParse('0.1')));
             delegatorBalance = delegatorBalance.add(availableAmount.mul(12));
@@ -475,14 +475,14 @@ describe('Staking Contract', () => {
 
             // make the next 3 undelegate requests ready to withdraw
             await timeTravel(mockProvider, 1000);
-            await stakingManager.widthdraw(delegator);
+            await stakingManager.widthdraw(delegator.address);
             delegatorBalance = delegatorBalance.add(availableAmount.mul(3));
             await checkUnbondingChanges(delegatorBalance, 15, 15);
         });
 
         it('withdraw an unbond with invalid status should fail', async () => {
             // no unbonding requests for withdrawing
-            await expect(stakingManager.widthdraw(delegator)).to.be.revertedWith('S009');
+            await expect(stakingManager.widthdraw(delegator.address)).to.be.revertedWith('S009');
         });
     });
 

--- a/test/VSQToken.test.ts
+++ b/test/VSQToken.test.ts
@@ -37,7 +37,7 @@ describe('VSQToken Contract', () => {
         await token.connect(delegator).increaseAllowance(staking.address, etherParse('15'));
     });
 
-    it.only('get balance of VSQT Token should work', async () => {
+    it('get balance of VSQT Token should work', async () => {
         await stakingManager.connect(delegator).delegate(indexer.address, etherParse('5'));
         await stakingManager.connect(delegator).delegate(indexer2.address, etherParse('5'));
         expect(await token.balanceOf(indexer.address)).to.equal(etherParse('1000'));
@@ -50,7 +50,7 @@ describe('VSQToken Contract', () => {
         await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('2'));
         await startNewEra(mockProvider, eraManager);
         expect(await vtoken.balanceOf(delegator.address)).to.equal(etherParse('15'));
-        await stakingManager.widthdraw(delegator);
+        await stakingManager.widthdraw(delegator.address);
         expect(await token.balanceOf(delegator.address)).to.equal(etherParse('6.998'));
         expect(await vtoken.balanceOf(delegator.address)).to.equal(etherParse('14.998'));
     });

--- a/test/VSQToken.test.ts
+++ b/test/VSQToken.test.ts
@@ -37,7 +37,7 @@ describe('VSQToken Contract', () => {
         await token.connect(delegator).increaseAllowance(staking.address, etherParse('15'));
     });
 
-    it('get balance of VSQT Token should work', async () => {
+    it.only('get balance of VSQT Token should work', async () => {
         await stakingManager.connect(delegator).delegate(indexer.address, etherParse('5'));
         await stakingManager.connect(delegator).delegate(indexer2.address, etherParse('5'));
         expect(await token.balanceOf(indexer.address)).to.equal(etherParse('1000'));
@@ -50,7 +50,7 @@ describe('VSQToken Contract', () => {
         await stakingManager.connect(delegator).undelegate(indexer.address, etherParse('2'));
         await startNewEra(mockProvider, eraManager);
         expect(await vtoken.balanceOf(delegator.address)).to.equal(etherParse('15'));
-        await stakingManager.connect(delegator).widthdraw();
+        await stakingManager.widthdraw(delegator);
         expect(await token.balanceOf(delegator.address)).to.equal(etherParse('6.998'));
         expect(await vtoken.balanceOf(delegator.address)).to.equal(etherParse('14.998'));
     });

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -90,6 +90,12 @@ export async function startNewEra(mockProvider: MockProvider, eraManager: EraMan
     return eraManager.eraNumber();
 }
 
+export async function eraTravel(mockProvider: MockProvider, eraManager: EraManager, eraCount: number) {
+    for (let i = 0; i < eraCount; i++) {
+        await startNewEra(mockProvider, eraManager);
+    }
+}
+
 export async function delay(sec: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, sec * 1000));
 }


### PR DESCRIPTION
## Changes:

- Change `withdraw` function can be called by anyone pass the valid indexer account
- Call withdraw function in `indexerCatchup` call