### PR TITLE
Make PriceOracle contract upgradable

### DIFF
--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -120,9 +120,13 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
      * @param metadata metadata to update
      */
     function updatePlanTemplateMetadata(uint256 templateId, bytes32 metadata) external onlyOwner {
-        require(v2templates[templateId].period > 0, 'PM004');
-
-        v2templates[templateId].metadata = metadata;
+        if (v2templates[templateId].period > 0) {
+            v2templates[templateId].metadata = metadata;
+        } else if (templates[templateId].period > 0) {
+            templates[templateId].metadata = metadata;
+        } else {
+            revert('PM004');
+        }
 
         emit PlanTemplateMetadataChanged(templateId, metadata);
     }
@@ -133,10 +137,13 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
      * @param active plan template active or not
      */
     function updatePlanTemplateStatus(uint256 templateId, bool active) external onlyOwner {
-        require(v2templates[templateId].period > 0, 'PM004');
-
-        v2templates[templateId].active = active;
-
+        if (v2templates[templateId].period > 0) {
+            v2templates[templateId].active = active;
+        } else if (templates[templateId].period > 0) {
+            templates[templateId].active = active;
+        } else {
+            revert('PM004');
+        }
         emit PlanTemplateStatusChanged(templateId, active);
     }
 
@@ -158,7 +165,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
     function createPlan(uint256 price, uint256 templateId, bytes32 deploymentId) external {
         require(!(IEraManager(settings.getEraManager()).maintenance()), 'G019');
         require(price > 0, 'PM005');
-        require(v2templates[templateId].active, 'PM006');
+        require(getPlanTemplate(templateId).active, 'PM006');
         require(limits[msg.sender][deploymentId] < limit, 'PM007');
 
         plans[nextPlanId] = Plan(msg.sender, price, templateId, deploymentId, true);

--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -200,7 +200,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
         }
 
         //stable price mode
-        PlanTemplateV2 memory template = v2templates[plan.templateId];
+        PlanTemplateV2 memory template = getPlanTemplate(plan.templateId);
         uint256 sqtPrice = convertPlanPriceToSQT(template.priceToken, plan.price);
 
         // create closed service agreement contract
@@ -210,7 +210,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
             deploymentId,
             sqtPrice,
             block.timestamp,
-            v2templates[plan.templateId].period,
+            template.period,
             planId,
             plan.templateId
         );
@@ -236,7 +236,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
      * @notice Get a specific plan templates
      * @param templateId plan template id
      */
-    function getPlanTemplate(uint256 templateId) external view returns (PlanTemplateV2 memory) {
+    function getPlanTemplate(uint256 templateId) public view returns (PlanTemplateV2 memory) {
         if (v2templates[templateId].period > 0) {
             return v2templates[templateId];
         } else {

--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -140,15 +140,6 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
         emit PlanTemplateStatusChanged(templateId, active);
     }
 
-    function convertPlanPriceToSQT(address priceToken, uint256 price) public view returns (uint256) {
-        if (priceToken == settings.getSQToken()){
-            return price;
-        }
-
-        uint256 assetPrice = IPriceOracle(settings.getPriceOracle()).getAssetPrice(priceToken, settings.getSQToken());
-        return price * 1e18 / assetPrice;
-    }
-
     /**
      * @notice Allow Indexer to create a Plan basing on a specific plan template.
      * @param price plan price
@@ -201,7 +192,7 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
 
         //stable price mode
         PlanTemplateV2 memory template = getPlanTemplate(plan.templateId);
-        uint256 sqtPrice = convertPlanPriceToSQT(template.priceToken, plan.price);
+        uint256 sqtPrice = IPriceOracle(settings.getPriceOracle()).convertPrice(template.priceToken, settings.getSQToken(), plan.price);
 
         // create closed service agreement contract
         ClosedServiceAgreementInfo memory agreement = ClosedServiceAgreementInfo(

--- a/contracts/PlanManager.sol
+++ b/contracts/PlanManager.sol
@@ -141,11 +141,12 @@ contract PlanManager is Initializable, OwnableUpgradeable, IPlanManager {
     }
 
     function convertPlanPriceToSQT(address priceToken, uint256 price) public view returns (uint256) {
-        if (priceToken != settings.getSQToken()){
-            return price * 1e18 / IPriceOracle(settings.getPriceOracle()).getAssetPrice(priceToken, settings.getSQToken());
-        } else {
+        if (priceToken == settings.getSQToken()){
             return price;
         }
+
+        uint256 assetPrice = IPriceOracle(settings.getPriceOracle()).getAssetPrice(priceToken, settings.getSQToken());
+        return price * 1e18 / assetPrice;
     }
 
     /**

--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -3,9 +3,12 @@
 
 pragma solidity 0.8.15;
 
-import '@openzeppelin/contracts/access/Ownable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 
-contract PriceOracle is Ownable {
+import './interfaces/IPriceOracle.sol';
+
+contract PriceOracle is IPriceOracle, Initializable, OwnableUpgradeable {
     ///@notice the price of assetA in assetB
     mapping(address => mapping(address => uint256)) public prices;
 
@@ -21,7 +24,9 @@ contract PriceOracle is Ownable {
     ///@notice the controller account which can change price
     address public controller;
 
-    constructor(uint256 _sizeLimit, uint256 _blockLimit) Ownable() {
+    function initialize(uint256 _sizeLimit, uint256 _blockLimit) external initializer {
+        __Ownable_init();
+
         sizeLimit = _sizeLimit;
         blockLimit = _blockLimit;
     }

--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -74,7 +74,7 @@ contract PriceOracle is IPriceOracle, Initializable, OwnableUpgradeable {
         }
 
         latestPriceBlock = block.number;
-        prices[assetFrom][assetTo] = assetToAmount * enlargementFactor / assetToAmount;
+        prices[assetFrom][assetTo] = price;
         emit PricePosted(assetFrom, assetTo, prePrice, price);
     }
 

--- a/contracts/interfaces/IPlanManager.sol
+++ b/contracts/interfaces/IPlanManager.sol
@@ -42,5 +42,4 @@ interface IPlanManager {
 
     function getPlanTemplate(uint256 templateId) external view returns (PlanTemplateV2 memory);
 
-    function convertPlanPriceToSQT(address priceToken, uint256 price) external view returns (uint256);
 }

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -4,5 +4,5 @@
 pragma solidity 0.8.15;
 
 interface IPriceOracle {
-    function getAssetPrice(address assetA, address assetB) external view returns (uint);
+    function getAssetPrice(address assetA, address assetB) external view returns (uint256);
 }

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -4,5 +4,6 @@
 pragma solidity 0.8.15;
 
 interface IPriceOracle {
-    function getAssetPrice(address assetA, address assetB) external view returns (uint256);
+    function getAssetPrice(address fromToken, address toToken) external view returns (uint256);
+    function convertPrice(address fromToken, address toToken, uint256 amount) external view returns (uint256);
 }

--- a/publish/testnet.json
+++ b/publish/testnet.json
@@ -6,10 +6,10 @@
         "lastUpdate": "Thu, 17 Aug 2023 21:12:08 GMT"
     },
     "Settings": {
-        "innerAddress": "0xfE2ADe8557E59F884f11edadf1Ae8Ce24Bfd442C",
+        "innerAddress": "0xFdAa698B9C9bDB788c9Aee7df94d9F4A95Bbaf7C",
         "address": "0x108553fB4A6F3b3044740B0212fb4Ce3a9cBef2E",
-        "bytecodeHash": "72687fabf5e34076c19c9fc4d7de25ac31eb1fe7f88c7ce9c0b7a657c4d51e26",
-        "lastUpdate": "Fri, 18 Aug 2023 01:50:01 GMT"
+        "bytecodeHash": "22e95eb1b6dda7712b7aa3ab9ee30b645e446f2670536e3116c8f024c1b83e6d",
+        "lastUpdate": "Wed, 23 Aug 2023 11:35:17 GMT"
     },
     "InflationController": {
         "innerAddress": "0x133989826b9CcA1F9aE520a09b7e368581a39697",
@@ -72,16 +72,16 @@
         "lastUpdate": "Thu, 17 Aug 2023 21:16:24 GMT"
     },
     "PlanManager": {
-        "innerAddress": "0xd88cBa0e8E5f7875777FA47FDF82d9669a980E7E",
+        "innerAddress": "0x576d090Ab4312BcC392146ff12518C8144e50626",
         "address": "0xc0f525Fe59F6f1D4A201dB36f93F4D2F34d6C45D",
-        "bytecodeHash": "bb80b55633f93b4bee02a1f77b274e321610773ad430639b82690da8ba2bbbdb",
-        "lastUpdate": "Thu, 17 Aug 2023 21:16:56 GMT"
+        "bytecodeHash": "72b2179afa28dfb6bdf87a65877fc7b2fa934ee21588162a7e3911d7dd91951e",
+        "lastUpdate": "Wed, 23 Aug 2023 11:35:34 GMT"
     },
     "PurchaseOfferMarket": {
-        "innerAddress": "0x754Ec915e899e2eA97cE89E977bB1426a152a473",
+        "innerAddress": "0x0f1C53a325891A0c899c604706B05C57371B81C1",
         "address": "0xB1360A9C92F129d744C72E0D2f10FDC4612e6dB9",
-        "bytecodeHash": "a4dc4d7b61d5bf63d91559f7ce2d3b7f1584415c15947a3b2ae19d19f9feace2",
-        "lastUpdate": "Thu, 17 Aug 2023 21:17:23 GMT"
+        "bytecodeHash": "3faa4df5e165a4896245ac5ad77350b28104c36c4fc78b6483385a3b41fb09e8",
+        "lastUpdate": "Wed, 23 Aug 2023 11:35:51 GMT"
     },
     "ServiceAgreementRegistry": {
         "innerAddress": "0xAF1b870D4F0639FeD175A103ebB1Feff163d8507",
@@ -132,10 +132,10 @@
         "lastUpdate": "Thu, 17 Aug 2023 21:21:21 GMT"
     },
     "DisputeManager": {
-        "innerAddress": "0x01db66f944c1C4e28741714B3De57869Fce3928c",
+        "innerAddress": "0xc5B4BD6b0775558A6588572585b5bb083640154A",
         "address": "0x1f32C28240384E2800AC3C28891713B763F1638B",
-        "bytecodeHash": "d81d057c21c8ff9c7479d6e71a4be450a94ab018f01a9d669d3702112a96d284",
-        "lastUpdate": "Thu, 17 Aug 2023 21:21:48 GMT"
+        "bytecodeHash": "c1ca58d833d56f490f98565be2e18425544a0146dd2e940090c77d8fe6164bff",
+        "lastUpdate": "Wed, 23 Aug 2023 11:36:10 GMT"
     },
     "ConsumerRegistry": {
         "innerAddress": "0x974B148bc0f2eDaAfbC8368EB000b8e0AAe237d5",

--- a/publish/testnet.json
+++ b/publish/testnet.json
@@ -142,5 +142,11 @@
         "address": "0xCde3e652f0aF75cE21CE3546c73D80807E2b5539",
         "bytecodeHash": "1b51ca8446a48c6022b81bf868a0a0db85b98ddf3cd26c11f5a4e9b8089372c9",
         "lastUpdate": "Thu, 17 Aug 2023 21:22:16 GMT"
+    },
+    "PriceOracle": {
+        "innerAddress": "0xe5546fca97f790DE7A8C00b18204eC21E114Bd79",
+        "address": "0x1099Aba6B6fEeC85493f54C72266ED9c1BF070cA",
+        "bytecodeHash": "f44474d7057fb38fe3c639ab2f64b216300f3f656e4ff3a58a3f7f5d1c096d9b",
+        "lastUpdate": "Wed, 23 Aug 2023 11:21:37 GMT"
     }
 }

--- a/scripts/contracts.ts
+++ b/scripts/contracts.ts
@@ -1,66 +1,65 @@
-import {Wallet} from '@ethersproject/wallet';
-import {BaseContract, BigNumber, ContractFactory, Signer} from 'ethers';
-import {Provider} from '@ethersproject/abstract-provider';
+import { Provider } from '@ethersproject/abstract-provider';
+import { Wallet } from '@ethersproject/wallet';
+import { BaseContract, BigNumber, ContractFactory, Signer } from 'ethers';
 
 import CONTRACTS from '../src/contracts';
 
 import {
+    Airdropper,
+    Airdropper__factory,
+    ConsumerHost,
+    ConsumerHost__factory,
+    ConsumerRegistry,
+    ConsumerRegistry__factory,
+    ContractName,
+    DisputeManager,
+    DisputeManager__factory,
+    EraManager,
+    EraManager__factory,
+    IndexerRegistry,
+    IndexerRegistry__factory,
+    InflationController,
+    InflationController__factory,
+    PermissionedExchange,
+    PermissionedExchange__factory,
+    PlanManager,
+    PlanManager__factory,
+    PriceOracle,
+    PriceOracle__factory,
     ProxyAdmin,
     ProxyAdmin__factory,
-    AdminUpgradeabilityProxy__factory,
-    InflationController__factory,
-    Staking__factory,
-    IndexerRegistry__factory,
-    QueryRegistry__factory,
-    InflationController,
-    Staking,
-    StakingManager,
-    StakingManager__factory,
-    Settings__factory,
-    QueryRegistry,
-    PlanManager__factory,
-    SQToken__factory,
-    ServiceAgreementRegistry__factory,
-    ServiceAgreementRegistry,
-    EraManager__factory,
-    PurchaseOfferMarket__factory,
-    Settings,
-    SQToken,
-    VSQToken,
-    VSQToken__factory,
-    EraManager,
-    IndexerRegistry,
-    PlanManager,
     PurchaseOfferMarket,
+    PurchaseOfferMarket__factory,
+    QueryRegistry,
+    QueryRegistry__factory,
     RewardsDistributer,
     RewardsDistributer__factory,
+    RewardsHelper,
+    RewardsHelper__factory,
     RewardsPool,
     RewardsPool__factory,
     RewardsStaking,
     RewardsStaking__factory,
-    RewardsHelper,
-    RewardsHelper__factory,
+    SQToken,
+    SQToken__factory,
+    ServiceAgreementRegistry,
+    ServiceAgreementRegistry__factory,
+    Settings,
+    Settings__factory,
+    Staking,
+    StakingManager,
+    StakingManager__factory,
+    Staking__factory,
     StateChannel,
     StateChannel__factory,
-    Airdropper,
-    Airdropper__factory,
-    PermissionedExchange,
-    PermissionedExchange__factory,
+    VSQToken,
+    VSQToken__factory,
     Vesting,
     Vesting__factory,
-    ConsumerHost,
-    ConsumerHost__factory,
-    DisputeManager,
-    DisputeManager__factory,
-    ConsumerRegistry__factory,
-    ConsumerRegistry,
-    PriceOracle,
-    PriceOracle__factory,
-    ContractName,
 } from '../src';
 
 export interface FactoryContstructor {
-    new (wallet: Wallet): ContractFactory;
+    new(wallet: Wallet): ContractFactory;
     connect: (address: string, signerOrProvider: Signer | Provider) => BaseContract;
     readonly abi: any;
 }
@@ -93,28 +92,30 @@ export type Contracts = {
     priceOracle: PriceOracle;
 };
 
-export const UPGRADEBAL_CONTRACTS: Partial<Record<keyof typeof CONTRACTS, [{bytecode: string}, FactoryContstructor]>> =
-    {
-        InflationController: [CONTRACTS.InflationController, InflationController__factory],
-        IndexerRegistry: [CONTRACTS.IndexerRegistry, IndexerRegistry__factory],
-        PlanManager: [CONTRACTS.PlanManager, PlanManager__factory],
-        QueryRegistry: [CONTRACTS.QueryRegistry, QueryRegistry__factory],
-        RewardsDistributer: [CONTRACTS.RewardsDistributer, RewardsDistributer__factory],
-        RewardsPool: [CONTRACTS.RewardsPool, RewardsPool__factory],
-        RewardsStaking: [CONTRACTS.RewardsStaking, RewardsStaking__factory],
-        RewardsHelper: [CONTRACTS.RewardsHelper, RewardsHelper__factory],
-        ServiceAgreementRegistry: [CONTRACTS.ServiceAgreementRegistry, ServiceAgreementRegistry__factory],
-        Staking: [CONTRACTS.Staking, Staking__factory],
-        StakingManager: [CONTRACTS.StakingManager, StakingManager__factory],
-        EraManager: [CONTRACTS.EraManager, EraManager__factory],
-        PurchaseOfferMarket: [CONTRACTS.PurchaseOfferMarket, PurchaseOfferMarket__factory],
-        StateChannel: [CONTRACTS.StateChannel, StateChannel__factory],
+export const UPGRADEBAL_CONTRACTS: Partial<Record<keyof typeof CONTRACTS, [{ bytecode: string }, FactoryContstructor]>> =
+{
+    InflationController: [CONTRACTS.InflationController, InflationController__factory],
+    IndexerRegistry: [CONTRACTS.IndexerRegistry, IndexerRegistry__factory],
+    PlanManager: [CONTRACTS.PlanManager, PlanManager__factory],
+    QueryRegistry: [CONTRACTS.QueryRegistry, QueryRegistry__factory],
+    RewardsDistributer: [CONTRACTS.RewardsDistributer, RewardsDistributer__factory],
+    RewardsPool: [CONTRACTS.RewardsPool, RewardsPool__factory],
+    RewardsStaking: [CONTRACTS.RewardsStaking, RewardsStaking__factory],
+    RewardsHelper: [CONTRACTS.RewardsHelper, RewardsHelper__factory],
+    ServiceAgreementRegistry: [CONTRACTS.ServiceAgreementRegistry, ServiceAgreementRegistry__factory],
+    Staking: [CONTRACTS.Staking, Staking__factory],
+    StakingManager: [CONTRACTS.StakingManager, StakingManager__factory],
+    EraManager: [CONTRACTS.EraManager, EraManager__factory],
+    PurchaseOfferMarket: [CONTRACTS.PurchaseOfferMarket, PurchaseOfferMarket__factory],
+    StateChannel: [CONTRACTS.StateChannel, StateChannel__factory],
 
-        PermissionedExchange: [CONTRACTS.PermissionedExchange, PermissionedExchange__factory],
-        ConsumerHost: [CONTRACTS.ConsumerHost, ConsumerHost__factory],
-        DisputeManager: [CONTRACTS.DisputeManager, DisputeManager__factory],
-        ConsumerRegistry: [CONTRACTS.ConsumerRegistry, ConsumerRegistry__factory],
-    };
+    PermissionedExchange: [CONTRACTS.PermissionedExchange, PermissionedExchange__factory],
+    ConsumerHost: [CONTRACTS.ConsumerHost, ConsumerHost__factory],
+    DisputeManager: [CONTRACTS.DisputeManager, DisputeManager__factory],
+    ConsumerRegistry: [CONTRACTS.ConsumerRegistry, ConsumerRegistry__factory],
+    PriceOracle: [CONTRACTS.PriceOracle, PriceOracle__factory],
+    Settings: [CONTRACTS.Settings, Settings__factory],
+};
 
 export const CONTRACT_FACTORY: Record<ContractName, FactoryContstructor> = {
     ProxyAdmin: ProxyAdmin__factory,

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -434,6 +434,8 @@ export async function upgradeContracts(
         const bytecodeHash = codeToHash(CONTRACTS[contract].bytecode);
         if (bytecodeHash !== deployment[contract]?.bytecodeHash) {
             changed.push(contract as any);
+        } else {
+            logger.info(`Contract ${contract} not changed`);
         }
     }
 
@@ -443,7 +445,8 @@ export async function upgradeContracts(
     }
 
     logger.info(`Contract Changed: ${changed.join(',')}`);
-    for (const contractName of changed) {
+    const _changed = ['Settings', 'PlanManager', 'PurchaseOfferMarket', 'DisputeManager'];
+    for (const contractName of _changed) {
         logger.info(`Upgrading ${contractName}`);
 
         const [_, factory] = UPGRADEBAL_CONTRACTS[contractName];

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -1,13 +1,13 @@
-import {Wallet} from '@ethersproject/wallet';
-import {BaseContract, Contract, Overrides} from 'ethers';
-import {readFileSync, writeFileSync} from 'fs';
+import { Wallet } from '@ethersproject/wallet';
+import { BaseContract, Contract, Overrides } from 'ethers';
+import { readFileSync, writeFileSync } from 'fs';
 import Pino from 'pino';
 import sha256 from 'sha256';
 import CONTRACTS from '../src/contracts';
-import {ContractDeployment, ContractName} from '../src/types';
-import {TextColor, colorText, getLogger} from './logger';
+import { ContractDeployment, ContractName } from '../src/types';
+import { TextColor, colorText, getLogger } from './logger';
 
-import {SubqueryNetwork} from '@subql/contract-sdk';
+import { SubqueryNetwork } from '@subql/contract-sdk';
 import {
     AdminUpgradeabilityProxy__factory,
     Airdropper,
@@ -67,7 +67,7 @@ function codeToHash(code: string) {
 async function getOverrides(): Promise<Overrides> {
     const price = await wallet.provider.getGasPrice();
     const gasPrice = price.add(20000000000); // add extra 15 gwei
-    return {gasPrice};
+    return { gasPrice };
 }
 
 export function saveDeployment(name: string, deployment: Partial<ContractDeployment>) {
@@ -88,7 +88,7 @@ async function deployContract<T extends BaseContract>(
     name: ContractName,
     options?: {
         proxyAdmin?: ProxyAdmin;
-        initConfig?: (string | string[])[];
+        initConfig?: (string | number | string[])[];
         deployConfig?: Config[];
     }
 ): Promise<T> {
@@ -104,7 +104,7 @@ async function deployContract<T extends BaseContract>(
 
     let contract: T;
     let innerAddress = '';
-    const {proxyAdmin, initConfig} = options ?? {};
+    const { proxyAdmin, initConfig } = options ?? {};
     const deployConfig = options?.deployConfig ?? [];
 
     if (proxyAdmin) {
@@ -184,7 +184,7 @@ function updateDeployment(
 export async function deployContracts(
     _wallet: Wallet,
     _config: ContractConfig,
-    options?: {network: SubqueryNetwork; confirms: number; history: boolean}
+    options?: { network: SubqueryNetwork; confirms: number; history: boolean }
 ): Promise<[Partial<ContractDeployment>, Contracts]> {
     wallet = _wallet;
     config = _config;
@@ -221,13 +221,13 @@ export async function deployContracts(
 
         //deploy Airdropper contract
         const [settleDestination] = config['Airdropper'];
-        const airdropper = await deployContract<Airdropper>('Airdropper', {deployConfig: [settleDestination]});
+        const airdropper = await deployContract<Airdropper>('Airdropper', { deployConfig: [settleDestination] });
 
         //deploy vesting contract
-        const vesting = await deployContract<Vesting>('Vesting', {deployConfig: [deployment.SQToken.address]});
+        const vesting = await deployContract<Vesting>('Vesting', { deployConfig: [deployment.SQToken.address] });
 
         // deploy Staking contract
-        const staking = await deployContract<Staking>('Staking', {proxyAdmin, initConfig: [settingsAddress]});
+        const staking = await deployContract<Staking>('Staking', { proxyAdmin, initConfig: [settingsAddress] });
 
         // deploy StakingManager contract
         const stakingManager = await deployContract<StakingManager>('StakingManager', {
@@ -236,7 +236,7 @@ export async function deployContracts(
         });
 
         // deploy Era manager
-        const eraManager = await deployContract<EraManager>('EraManager', {proxyAdmin, initConfig: [settingsAddress]});
+        const eraManager = await deployContract<EraManager>('EraManager', { proxyAdmin, initConfig: [settingsAddress] });
 
         // deploy IndexerRegistry contract
         const indexerRegistry = await deployContract<IndexerRegistry>('IndexerRegistry', {
@@ -324,7 +324,8 @@ export async function deployContracts(
 
         // delpoy PriceOracle contract
         const priceOracle = await deployContract<PriceOracle>('PriceOracle', {
-            deployConfig: [10, 3600],
+            proxyAdmin,
+            initConfig: [10, 3600],
         });
 
         // Register addresses on settings contract
@@ -451,7 +452,7 @@ export async function upgradeContracts(
             continue;
         }
 
-        const {address} = deployment[contractName];
+        const { address } = deployment[contractName];
         const [innerAddr] = await upgradeContract(proxyAdmin, address, factory, wallet, confirms);
         deployment[contractName] = {
             innerAddress: innerAddr,

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -445,8 +445,7 @@ export async function upgradeContracts(
     }
 
     logger.info(`Contract Changed: ${changed.join(',')}`);
-    const _changed = ['Settings', 'PlanManager', 'PurchaseOfferMarket', 'DisputeManager'];
-    for (const contractName of _changed) {
+    for (const contractName of changed) {
         logger.info(`Upgrading ${contractName}`);
 
         const [_, factory] = UPGRADEBAL_CONTRACTS[contractName];

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -2,8 +2,8 @@
 
 import { ContractDeployment, SubqueryNetwork } from './types';
 
-import moduleAlias from 'module-alias';
-moduleAlias.addAlias('./publish', '../publish');
+// import moduleAlias from 'module-alias';
+// moduleAlias.addAlias('./publish', '../publish');
 
 import keplerDeployment from './publish/kepler.json';
 import mainnetDeployment from './publish/mainnet.json';

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -2,8 +2,8 @@
 
 import { ContractDeployment, SubqueryNetwork } from './types';
 
-// import moduleAlias from 'module-alias';
-// moduleAlias.addAlias('./publish', '../publish');
+import moduleAlias from 'module-alias';
+moduleAlias.addAlias('./publish', '../publish');
 
 import keplerDeployment from './publish/kepler.json';
 import mainnetDeployment from './publish/mainnet.json';

--- a/test/PlanManager.test.ts
+++ b/test/PlanManager.test.ts
@@ -295,22 +295,14 @@ describe('PlanManger Contract', () => {
             await queryRegistry.startIndexing(DEPLOYMENT_ID);
             await queryRegistry.updateIndexingStatusToReady(DEPLOYMENT_ID);
 
-            //set oracle 
-            //1 USDC = 13 SQT
-            await priceOracle.setAssetPrice(usdc, token.address, BigNumber.from("13000000000000000000000000000000"));
+            //set oracle
+            //1 USDC(ether) = 13 SQT(ether), <> 1 USDC = 13e12
+            await priceOracle.setAssetPrice(usdc, token.address, 1, 13e12);
             // create plan template
             await planManager.createPlanTemplate(time.duration.days(3).toString(), 1000, 100, token.address, METADATA_HASH);
             // default plan -> planId: 1
-            //price: 2.73 usdc 
+            //price: 2.73 usdc
             await planManager.createPlan(BigNumber.from("2730000"), 0, constants.ZERO_BYTES32); // plan id = 1;
-        });
-
-        it('feed price to price oracle should work', async () => {
-            let tokenA = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
-            let tokenB = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
-            await expect(priceOracle.getAssetPrice(tokenA, tokenB)).to.be.revertedWith("OR001");
-            await priceOracle.setAssetPrice(tokenA, tokenB, etherParse('1'));
-            expect(await priceOracle.getAssetPrice(tokenA, tokenB)).to.be.eq(etherParse('1'));
         });
 
         it('create a plan with allowed stable price should work', async () => {

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -11,15 +11,15 @@ describe('PriceOracle Contract', () => {
     const mockProvider = waffle.provider;
     let wallet_0, wallet_1, wallet_2;
     let priceOracle: PriceOracle;
-    const assetA = '0x0000000000000000000000000000000000000000';
-    const assetB = '0x0000000000000000000000000000000000000001';
-    const price = 100;
+    const assetFrom = '0x0000000000000000000000000000000000000000';
+    const assetTo = '0x0000000000000000000000000000000000000001';
+    const price = 100; // 1 assetA to 100 assetB
 
     beforeEach(async () => {
         [wallet_0, wallet_1, wallet_2] = await ethers.getSigners();
         const deployment = await deployContracts(wallet_0, wallet_1);
         priceOracle = deployment.priceOracle;
-        await priceOracle.setAssetPrice(assetA, assetB, price);
+        await priceOracle.setAssetPrice(assetFrom, assetTo, 1, price);
     });
 
     describe('update paramsters', () => {
@@ -33,43 +33,58 @@ describe('PriceOracle Contract', () => {
             expect(await priceOracle.controller()).to.equal(wallet_1.address);
         });
     });
+    describe('convert price', () => {
+        it('can convert as price specified', async () => {
+            const fromPrice = 1e12;
+            const price = 100;
+            const enlargement = await priceOracle.enlargementFactor();
+            expect(await priceOracle.getAssetPrice(assetFrom,assetTo)).to.eq(enlargement.mul(price));
+            const toPrice = await priceOracle.convertPrice(assetFrom, assetTo, fromPrice);
+            await expect(toPrice.toNumber()).to.eq(fromPrice*price)
+        })
+        it('return directly for same asset', async () => {
+            const fromPrice = 1e12;
+            const toPrice = await priceOracle.convertPrice(assetFrom, assetFrom, fromPrice);
+            await expect(toPrice).to.eq(fromPrice)
+        })
+    })
 
     describe('set price', () => {
         it('controller set price should work', async () => {
             await priceOracle.setLimit(10, 100);
-            await priceOracle.setController(wallet_1.address); ``
+            await priceOracle.setController(wallet_1.address);
 
             await blockTravel(mockProvider, 100);
 
             const price1 = (price / 100) * 91; // -9%
-            await priceOracle.connect(wallet_1).setAssetPrice(assetA, assetB, price1);
-            await priceOracle.setAssetPrice(assetA, assetB, price);
+            await priceOracle.connect(wallet_1).setAssetPrice(assetFrom, assetTo, 1, price1);
+            await priceOracle.setAssetPrice(assetFrom, assetTo,1, price);
 
             // time limit
-            await expect(priceOracle.connect(wallet_1).setAssetPrice(assetA, assetB, price1)).to.be.revertedWith(
+            await expect(priceOracle.connect(wallet_1).setAssetPrice(assetFrom, assetTo, 1, price1)).to.be.revertedWith(
                 'OR002'
             );
 
             await blockTravel(mockProvider, 100);
 
             const price2 = (price / 100) * 109; // +9%
-            await priceOracle.connect(wallet_1).setAssetPrice(assetA, assetB, price2);
-            await priceOracle.setAssetPrice(assetA, assetB, price);
+            await priceOracle.connect(wallet_1).setAssetPrice(assetFrom, assetTo, 1, price2);
+            await priceOracle.setAssetPrice(assetFrom, assetTo, 1, price);
 
             await blockTravel(mockProvider, 100);
 
             const price3 = (price / 100) * 110; // +10%
-            await expect(priceOracle.connect(wallet_1).setAssetPrice(assetA, assetB, price3)).to.be.revertedWith(
+            await expect(priceOracle.connect(wallet_1).setAssetPrice(assetFrom, assetTo, 1, price3)).to.be.revertedWith(
                 'OR003'
             );
         });
         it('owner set price should work', async () => {
             const price1 = (price / 100) * 110; // +10%
-            await expect(priceOracle.connect(wallet_2).setAssetPrice(assetA, assetB, price1)).to.be.revertedWith(
+            await expect(priceOracle.connect(wallet_2).setAssetPrice(assetFrom, assetTo, 1, price1)).to.be.revertedWith(
                 'OR004'
             );
 
-            await expect(priceOracle.setAssetPrice(assetA, assetB, price1));
+            await expect(priceOracle.setAssetPrice(assetFrom, assetTo, 1, price1));
         });
     });
 });

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -4,7 +4,7 @@
 import { expect } from 'chai';
 import { ethers, waffle } from 'hardhat';
 import { PriceOracle } from '../src';
-import { blockTravel } from './helper';
+import { blockTravel, etherParse } from './helper';
 import { deployContracts } from './setup';
 
 describe('PriceOracle Contract', () => {


### PR DESCRIPTION
## Changes

- Enable `PriceOracle` contract to be upgradeable
- Update method in `IPriceOracle` interface
- Upgrade contracts: `Settings` `PlanManager` `PurchaseOfferMarket` `DisputeManager`