### PR TITLE
Allow update deployment and mark a deployment latest for a project

### DIFF
--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -170,6 +170,11 @@ contract ProjectRegistry is Initializable, OwnableUpgradeable, ERC721Upgradeable
         emit ProjectMetadataUpdated(msg.sender, projectId, metadataUri);
     }
 
+    function _updateProjectLatestDeployment(uint256 projectId, bytes32 deploymentId) internal {
+        projectInfos[projectId].latestDeploymentId = deploymentId;
+        emit ProjectLatestDeploymentUpdated(msg.sender, projectId, deploymentId);
+    }
+
     /**
      * @notice add a deployment to a project.
      */
@@ -188,8 +193,7 @@ contract ProjectRegistry is Initializable, OwnableUpgradeable, ERC721Upgradeable
         emit ProjectDeploymentUpdated(msg.sender, projectId, deploymentId, metadata);
         
         if (updateLatest && projectInfos[projectId].latestDeploymentId != deploymentId) {
-            projectInfos[projectId].latestDeploymentId = deploymentId;
-            emit ProjectLatestDeploymentUpdated(msg.sender, projectId, deploymentId);
+            _updateProjectLatestDeployment(projectId, deploymentId);
         }
     }
 
@@ -198,9 +202,7 @@ contract ProjectRegistry is Initializable, OwnableUpgradeable, ERC721Upgradeable
         require(deploymentInfos[deploymentId].projectId == projectId, 'PR007');
         require(projectInfos[projectId].latestDeploymentId != deploymentId, 'PR010');
 
-        projectInfos[projectId].latestDeploymentId = deploymentId;
-
-        emit ProjectLatestDeploymentUpdated(msg.sender, projectId, deploymentId);
+        _updateProjectLatestDeployment(projectId, deploymentId);
     }
 
     /**

--- a/contracts/ProjectRegistry.sol
+++ b/contracts/ProjectRegistry.sol
@@ -187,7 +187,7 @@ contract ProjectRegistry is Initializable, OwnableUpgradeable, ERC721Upgradeable
 
         emit ProjectDeploymentUpdated(msg.sender, projectId, deploymentId, metadata);
         
-        if (updateLatest) {
+        if (updateLatest && projectInfos[projectId].latestDeploymentId != deploymentId) {
             projectInfos[projectId].latestDeploymentId = deploymentId;
             emit ProjectLatestDeploymentUpdated(msg.sender, projectId, deploymentId);
         }

--- a/contracts/interfaces/IProjectRegistry.sol
+++ b/contracts/interfaces/IProjectRegistry.sol
@@ -33,10 +33,11 @@ interface IProjectRegistry {
 
     function updateProjectMetadata(uint256 projectId, string memory metadataUri) external;
 
-    function updateDeployment(
+    function addOrUpdateDeployment(
         uint256 projectId,
         bytes32 deploymentId,
-        bytes32 metadata
+        bytes32 metadata,
+        bool updateLatest
     ) external;
 
     function startService(bytes32 deploymentId) external;

--- a/contracts/interfaces/IProjectRegistry.sol
+++ b/contracts/interfaces/IProjectRegistry.sol
@@ -33,12 +33,9 @@ interface IProjectRegistry {
 
     function updateProjectMetadata(uint256 projectId, string memory metadataUri) external;
 
-    function addOrUpdateDeployment(
-        uint256 projectId,
-        bytes32 deploymentId,
-        bytes32 metadata,
-        bool updateLatest
-    ) external;
+    function addOrUpdateDeployment(uint256 projectId, bytes32 deploymentId, bytes32 metadata, bool updateLatest) external;
+    
+    function setProjectLatestDeployment(uint256 projectId, bytes32 deploymentId) external;
 
     function startService(bytes32 deploymentId) external;
 

--- a/publish/ABI/ProjectRegistry.json
+++ b/publish/ABI/ProjectRegistry.json
@@ -72,49 +72,6 @@
         "anonymous": false,
         "inputs": [
             {
-                "indexed": true,
-                "internalType": "address",
-                "name": "creator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "projectId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "projectMetadata",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "enum ProjectType",
-                "name": "projectType",
-                "type": "uint8"
-            },
-            {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "deploymentId",
-                "type": "bytes32"
-            },
-            {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "deploymentMetadata",
-                "type": "bytes32"
-            }
-        ],
-        "name": "CreateProject",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
                 "indexed": false,
                 "internalType": "uint8",
                 "name": "version",
@@ -154,6 +111,130 @@
             }
         ],
         "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "creator",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "projectMetadata",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum ProjectType",
+                "name": "projectType",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "deploymentId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "deploymentMetadata",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ProjectCreated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "deploymentId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "metadata",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ProjectDeploymentUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "deploymentId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ProjectLatestDeploymentUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "metadata",
+                "type": "string"
+            }
+        ],
+        "name": "ProjectMetadataUpdated",
         "type": "event"
     },
     {
@@ -204,68 +285,6 @@
             }
         ],
         "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "projectId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "deploymentId",
-                "type": "bytes32"
-            },
-            {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "metadata",
-                "type": "bytes32"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "updateLatest",
-                "type": "bool"
-            }
-        ],
-        "name": "UpdateProjectDeployment",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "projectId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "metadata",
-                "type": "string"
-            }
-        ],
-        "name": "UpdateProjectMetadata",
         "type": "event"
     },
     {
@@ -733,6 +752,24 @@
             }
         ],
         "name": "setCreatorRestricted",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "deploymentId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "setProjectLatestDeployment",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/ABI/ProjectRegistry.json
+++ b/publish/ABI/ProjectRegistry.json
@@ -232,6 +232,12 @@
                 "internalType": "bytes32",
                 "name": "metadata",
                 "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "updateLatest",
+                "type": "bool"
             }
         ],
         "name": "UpdateProjectDeployment",
@@ -271,6 +277,34 @@
             }
         ],
         "name": "addCreator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "projectId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "deploymentId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "metadata",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bool",
+                "name": "updateLatest",
+                "type": "bool"
+            }
+        ],
+        "name": "addOrUpdateDeployment",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -894,29 +928,6 @@
             }
         ],
         "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "projectId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "deploymentId",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "metadata",
-                "type": "bytes32"
-            }
-        ],
-        "name": "updateDeployment",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/revertcode.json
+++ b/publish/revertcode.json
@@ -118,6 +118,8 @@
     "PR006": "cannot stop indexing with an ongoing service agreement",
     "PR007": "Inconsistent project id and deployment id",
     "PR008": "deployment metadata not changed",
+    "PR009": "deployment id or metadata is empty",
+    "PR010": "project latest deployment id not changed",
     "RD001": "Waiting Era",
     "RD002": "Era expired",
     "RD003": "Waiting next era",

--- a/publish/revertcode.json
+++ b/publish/revertcode.json
@@ -117,6 +117,7 @@
     "PR005": "can not stop indexing for NOTINDEXING services",
     "PR006": "cannot stop indexing with an ongoing service agreement",
     "PR007": "Inconsistent project id and deployment id",
+    "PR008": "deployment metadata not changed",
     "RD001": "Waiting Era",
     "RD002": "Era expired",
     "RD003": "Waiting next era",

--- a/test/ProjectRegistry.test.ts
+++ b/test/ProjectRegistry.test.ts
@@ -173,7 +173,7 @@ describe('Project Registry Contract', () => {
             const [metadata, deploymentId] = [deploymentMetadatas[1], deploymentIds[1]];
             await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, metadata, true))
                 .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentId, metadata);
+                .withArgs(wallet_0.address, projectId, deploymentId, metadata, true);
 
             // check state changes
             const projectInfo = await projectRegistry.projectInfos(projectId);
@@ -212,7 +212,7 @@ describe('Project Registry Contract', () => {
             expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[1]);
             await expect(projectRegistry.addOrUpdateDeployment(projectId, deploymentIds[2], deploymentMetadatas[2], false))
                 .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentId, deploymentMetadatas[0], false);
+                .withArgs(wallet_0.address, projectId, deploymentIds[2], deploymentMetadatas[2], false);
 
             // check state changes
             projectInfo = await projectRegistry.projectInfos(projectId);

--- a/test/ProjectRegistry.test.ts
+++ b/test/ProjectRegistry.test.ts
@@ -1,8 +1,10 @@
+import { metadatas } from './constants';
 // Copyright (C) 2020-2023 SubProject Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { expect } from 'chai';
 import { ethers, waffle } from 'hardhat';
+import { constants } from 'ethers';
 
 import { IndexerRegistry, PlanManager, ProjectRegistry, PurchaseOfferMarket, SQToken, Settings, Staking } from '../src';
 import { METADATA_HASH, POI, deploymentIds, deploymentMetadatas, projectMetadatas } from './constants';
@@ -39,6 +41,7 @@ describe('Project Registry Contract', () => {
     let setting: Settings;
 
     const deploymentId = deploymentIds[0];
+    const deploymentId2 = deploymentIds[1];
     const projectMetadata = projectMetadatas[0];
     const deploymentMetadata = deploymentMetadatas[0];
 
@@ -107,7 +110,7 @@ describe('Project Registry Contract', () => {
             // create project
             const projectId = 1;
             await expect(createProject())
-                .to.be.emit(projectRegistry, 'CreateProject')
+                .to.be.emit(projectRegistry, 'ProjectCreated')
                 .withArgs(wallet_0.address, projectId, projectMetadata, ProjectType.SUBQUERY, deploymentId, deploymentMetadata);
 
             // check state updates
@@ -153,14 +156,12 @@ describe('Project Registry Contract', () => {
     });
 
     describe('Update Project', () => {
-        beforeEach(async () => {
-            await createProject();
-        });
+        beforeEach(async () => await createProject());
 
         it('update project metadata should work', async () => {
             const newProjectMetadata = projectMetadatas[1];
             await expect(projectRegistry.updateProjectMetadata(1, newProjectMetadata))
-                .to.be.emit(projectRegistry, 'UpdateProjectMetadata')
+                .to.be.emit(projectRegistry, 'ProjectMetadataUpdated')
                 .withArgs(wallet_0.address, 1, newProjectMetadata);
 
             // check state changes
@@ -170,10 +171,40 @@ describe('Project Registry Contract', () => {
 
         it('add new deployment to project should work', async () => {
             const projectId = 1;
-            const [metadata, deploymentId] = [deploymentMetadatas[1], deploymentIds[1]];
+            let [metadata, deploymentId] = [deploymentMetadatas[1], deploymentIds[1]];
             await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, metadata, true))
-                .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentId, metadata, true);
+                .to.be.emit(projectRegistry, 'ProjectDeploymentUpdated')
+                .withArgs(wallet_0.address, projectId, deploymentId, metadata);
+
+            // check state changes
+            let projectInfo = await projectRegistry.projectInfos(projectId);
+            let deploymentInfo = await projectRegistry.deploymentInfos(deploymentId);
+            expect(projectInfo.latestDeploymentId).to.equal(deploymentId);
+            expect(projectInfo.projectType).to.equal(ProjectType.SUBQUERY);
+            expect(deploymentInfo.projectId).to.equal(projectId);
+            expect(deploymentInfo.metadata).to.equal(metadata);
+
+            // add the second deployment without setting it as latest
+            [metadata, deploymentId] = [deploymentMetadatas[2], deploymentIds[2]];
+            await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, metadata, false))
+                .to.be.emit(projectRegistry, 'ProjectDeploymentUpdated')
+                .withArgs(wallet_0.address, projectId, deploymentId, metadata);
+
+            // check state changes
+            projectInfo = await projectRegistry.projectInfos(projectId);
+            deploymentInfo = await projectRegistry.deploymentInfos(deploymentId);
+            expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[1]);
+            expect(projectInfo.projectType).to.equal(ProjectType.SUBQUERY);
+            expect(deploymentInfo.projectId).to.equal(projectId);
+            expect(deploymentInfo.metadata).to.equal(metadata);
+        });
+
+        it('update deployment\'s metadata should work', async () => {
+            const projectId = 1;
+            const metadata = deploymentMetadatas[1];
+            await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, metadata, false))
+                .to.be.emit(projectRegistry, 'ProjectDeploymentUpdated')
+                .withArgs(wallet_0.address, projectId, deploymentId, metadata);
 
             // check state changes
             const projectInfo = await projectRegistry.projectInfos(projectId);
@@ -184,60 +215,19 @@ describe('Project Registry Contract', () => {
             expect(deploymentInfo.metadata).to.equal(metadata);
         });
 
-        it('update deployment\'s metadata should work', async () => {
+        it('update selected deployment as latest should work', async () => {
             const projectId = 1;
-            const [metadata, deploymentId] = [deploymentMetadatas[1], deploymentIds[1]];
-            await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, metadata, true))
-                .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentId, metadata, true);
-
-            await expect(projectRegistry.addOrUpdateDeployment(1, deploymentId, deploymentMetadatas[2], false))
-                .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentId, deploymentMetadatas[2], false);
-
-            // check state changes
-            const projectInfo = await projectRegistry.projectInfos(projectId);
-            const deploymentInfo = await projectRegistry.deploymentInfos(deploymentId);
+            await projectRegistry.addOrUpdateDeployment(projectId, deploymentId2, deploymentMetadata, false);
+            let projectInfo = await projectRegistry.projectInfos(projectId);
             expect(projectInfo.latestDeploymentId).to.equal(deploymentId);
-            expect(projectInfo.projectType).to.equal(ProjectType.SUBQUERY);
-            expect(deploymentInfo.projectId).to.equal(projectId);
-            expect(deploymentInfo.metadata).to.equal(deploymentMetadatas[2]);
-        });
 
-        it('add deployment\'s metadata without marking it as latest should work', async () => {
-            const projectId = 1;
-            await projectRegistry.addOrUpdateDeployment(projectId, deploymentIds[1], deploymentMetadatas[1], true)
-            // check state changes
-            let projectInfo = await projectRegistry.projectInfos(projectId);
-            expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[1]);
-            await expect(projectRegistry.addOrUpdateDeployment(projectId, deploymentIds[2], deploymentMetadatas[2], false))
-                .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentIds[2], deploymentMetadatas[2], false);
+            await expect(projectRegistry.setProjectLatestDeployment(projectId, deploymentId2))
+                .to.be.emit(projectRegistry, 'ProjectLatestDeploymentUpdated')
+                .withArgs(wallet_0.address, projectId, deploymentId2);
 
             // check state changes
             projectInfo = await projectRegistry.projectInfos(projectId);
-            expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[1]);
-            let deploymentInfo = await projectRegistry.deploymentInfos(deploymentIds[1]);
-            expect(deploymentInfo.projectId).to.equal(projectId);
-            expect(deploymentInfo.metadata).to.equal(deploymentMetadatas[1]);
-            deploymentInfo = await projectRegistry.deploymentInfos(deploymentIds[2]);
-            expect(deploymentInfo.projectId).to.equal(projectId);
-            expect(deploymentInfo.metadata).to.equal(deploymentMetadatas[2]);
-        });
-
-        it('update old deployment as latest should work', async () => {
-            const projectId = 1;
-            await projectRegistry.addOrUpdateDeployment(projectId, deploymentIds[1], deploymentMetadatas[1], true)
-            // check state changes
-            let projectInfo = await projectRegistry.projectInfos(projectId);
-            expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[1]);
-            await expect(projectRegistry.addOrUpdateDeployment(projectId, deploymentIds[0], deploymentMetadatas[0], true))
-                .to.be.emit(projectRegistry, 'UpdateProjectDeployment')
-                .withArgs(wallet_0.address, projectId, deploymentIds[0], deploymentMetadatas[0], true);
-
-            // check state changes
-            projectInfo = await projectRegistry.projectInfos(projectId);
-            expect(projectInfo.latestDeploymentId).to.equal(deploymentIds[0]);
+            expect(projectInfo.latestDeploymentId).to.equal(deploymentId2);
         });
 
         it('can add new deployment to project with new account after owner transferred', async () => {
@@ -264,34 +254,55 @@ describe('Project Registry Contract', () => {
             expect(deploymentInfo.metadata).to.equal(metadata);
         });
 
-        it('update project and deployment with invalid params should fail', async () => {
-            // no permission to update project
+        it('update project metadata with invalid params should fail', async () => {
+            // invalid owner
             await expect(
                 projectRegistry.connect(wallet_1).updateProjectMetadata(1, projectMetadata)
             ).to.be.revertedWith('PR004');
-            // no permission to add deployment
-            await expect(
-                projectRegistry.connect(wallet_1).addOrUpdateDeployment(1, deploymentIds[1], deploymentMetadatas[1],true)
-            ).to.be.revertedWith('PR004');
-            // no changes after the update
-            await expect(
-                projectRegistry.addOrUpdateDeployment(1, deploymentIds[0], deploymentMetadatas[0],true)
-            ).to.be.revertedWith('PR008');
-            await expect(
-                projectRegistry.addOrUpdateDeployment(1, deploymentIds[0], deploymentMetadatas[0],false)
-            ).to.be.revertedWith('PR008');
+        });
 
-            // deployment existed
-            await projectRegistry.addCreator(wallet_1.address);
-            await projectRegistry.connect(wallet_1).createProject(
+        it('update deployment with invalid params should fail', async () => {
+            // invalid owner
+            await expect(
+                projectRegistry.connect(wallet_1).addOrUpdateDeployment(1, deploymentId, deploymentMetadata, true)
+            ).to.be.revertedWith('PR004');
+            // empty metadata or deploymentId
+            await expect(
+                projectRegistry.addOrUpdateDeployment(1, deploymentId, constants.HashZero, true)
+            ).to.be.revertedWith('PR009');    
+            await expect(
+                projectRegistry.addOrUpdateDeployment(1, constants.HashZero, metadatas[0], true)
+            ).to.be.revertedWith('PR009');
+
+            // create another project
+            await projectRegistry.createProject(
                 projectMetadatas[1],
                 deploymentMetadatas[1],
                 deploymentIds[1],
                 ProjectType.SUBQUERY
             );
+
             await expect(
-                projectRegistry.connect(wallet_1).addOrUpdateDeployment(2, deploymentId, deploymentMetadatas[1], true)
+                projectRegistry.addOrUpdateDeployment(1, deploymentIds[1], deploymentMetadatas[1], true)
             ).to.be.revertedWith('PR007');
+            await expect(
+                projectRegistry.addOrUpdateDeployment(1, deploymentId, deploymentMetadata, true)
+            ).to.be.revertedWith('PR008');
+        });
+
+        it('set project latest deployment with invalid params should fail', async () => {
+            // invalid owner 
+            await expect(
+                projectRegistry.connect(wallet_1).setProjectLatestDeployment(1, deploymentId)
+            ).to.be.revertedWith('PR004');
+            // inconsistent project id and deployment id
+            await expect(
+                projectRegistry.setProjectLatestDeployment(1, deploymentIds[1])
+            ).to.be.revertedWith('PR007');
+            // deployment id already set as latest
+            await expect(
+                projectRegistry.setProjectLatestDeployment(1, deploymentId)
+            ).to.be.revertedWith('PR010');
         });
     });
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -13,7 +13,8 @@ export const POI = '0xab3921276c8067fe0c82def3e5ecfd8447f1961bc85768c2a56e6bd26d
 
 export const projectMetadatas = [
     'QmZGAZQ7e1oZgfuK4V29Fa5gveYK3G2zEwvUzTZKNvSBsm',
-    'QmeeqBHdVu7iYnhVE9ZiYEKTWe4jXVUD5pVoGXT6LbCP2t'
+    'QmeeqBHdVu7iYnhVE9ZiYEKTWe4jXVUD5pVoGXT6LbCP2t',
+    'QmeHdVHdVuHdVnhVE9ZiYEKTWe4jXVUD5HdVGXT6LbCHdV'
 ]
 
 export const metadatas = [
@@ -25,6 +26,7 @@ export const metadatas = [
 export const deploymentMetadatas = [
     '0xaec921276c8067fe0c82def3e5ecfd8447f1961bc85768c2a56e6bd26d3c0c55',
     '0xccc921276c8067fe0c82def3e5ecfd8447f1961bc85768c2a56e6bd26d3c0c55',
+    '0xccc921276c8067fe0c82def3e5ecfd8447f1961bc85768c2a56e6bd26d3c0c5a',
 ];
 
 export const deploymentIds = [


### PR DESCRIPTION
* rename `updateDeployment` to `addOrUpdateDeployment` since that's what it is doing
* allows updating existing deployment as long as
  * sender is the owner of the project
  * It actually writes the storage in the tx
* allows marking an old deployment as latest
* allows adding a new deployment without marking it latest
* add `bool updateLatest` to `addOrUpdateDeployment(..., bool updateLatest)`
* add `bool updateLatest` to `event UpdateProjectDeployment(..., bool updateLatest)`
* add new error code `PR007: deployment metadata not changed`
* update tests