### PR TITLE
Allow under staked

### DIFF
--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -193,7 +193,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
             accRewardsPerAllocatedToken
         );
 
-        return _fixRewardsWithMissedLaborAndOverflow(totalRewards, runnerDeplReward, sa.overflowTime(_runner));
+        return _fixRewardsWithMissedLaborAndOverflow(totalRewards, runnerDeplReward, sa.overAllocationTime(_runner));
     }
 
     /**
@@ -454,7 +454,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
 
         runnerDeplReward.accRewardsPerToken = accRewardsPerAllocatedToken;
         uint256 burnt;
-        uint256 totalOverflowTime = sa.overflowTime(_runner);
+        uint256 totalOverflowTime = sa.overAllocationTime(_runner);
         (reward, burnt) = _fixRewardsWithMissedLaborAndOverflow(reward, runnerDeplReward, totalOverflowTime);
 
         runnerDeplReward.lastClaimedAt = block.timestamp;

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -150,7 +150,7 @@ contract RewardsPool is IRewardsPool, Initializable, OwnableUpgradeable {
         // runner joined the deployment pool firstly.
         if (pool.labor[runner] == 0) {
             IStakingManager stakingManager = IStakingManager(settings.getContractAddress(SQContracts.StakingManager));
-            uint256 myStake = stakingManager.getTotalStakingAmount(runner);
+            uint256 myStake = stakingManager.getEffectiveTotalStake(runner);
             if (myStake == 0) {
                 // skip unclaimDeployments change, this runner can not claim
                 // if this is the only reward this pool get in this era, the reward is locked forever in the pool

--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -24,6 +24,7 @@ import './utils/MathUtil.sol';
  * @title Rewards Staking Contract
  * @notice ### Overview
  * Keep tracing the pending staking and commission rate and last settled era.
+ * Split from RewardsDistributor to keep contract size under control
  */
 contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
     using SafeERC20 for IERC20;

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -43,8 +43,8 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     // -- Events --
     event StakeAllocationAdded(bytes32 deploymentId, address runner, uint256 amount);
     event StakeAllocationRemoved(bytes32 deploymentId, address runner, uint256 amount);
-    event StakeOverflowStarted(address indexer, uint256 start);
-    event StakeOverflowEnded(address indexer, uint256 end, uint256 time);
+    event OverAllocationStarted(address runner, uint256 start);
+    event OverAllocationEnded(address runner, uint256 end, uint256 time);
     // -- Functions --
 
     /**
@@ -63,16 +63,16 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     function onStakeUpdate(address _runner, uint256 _amount) external {
         require(msg.sender == settings.getContractAddress(SQContracts.RewardsStaking), 'SAL01');
         RunnerAllocation storage ia = _runnerAllocations[_runner];
-        uint256 total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);
+        ia.total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);
 
-        if (ia.overflowAt == 0 && total < ia.used) {
+        if (ia.overflowAt == 0 && ia.total < ia.used) {
             // new overflow
-            emit StakeOverflowStarted(_runner, block.timestamp);
+            emit OverAllocationStarted(_runner, block.timestamp);
 
             ia.overflowAt = block.timestamp;
-        } else if (ia.overflowAt != 0 && total >= ia.used) {
+        } else if (ia.overflowAt != 0 && ia.total >= ia.used) {
             // recover from overflow
-            emit StakeOverflowEnded(_runner, block.timestamp, block.timestamp - ia.overflowAt);
+            emit OverAllocationEnded(_runner, block.timestamp, block.timestamp - ia.overflowAt);
 
             ia.overflowTime += block.timestamp - ia.overflowAt;
             ia.overflowAt = 0;
@@ -87,8 +87,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         rb.collectAllocationReward(_deployment, _runner);
 
         RunnerAllocation storage ia = _runnerAllocations[_runner];
-        uint256 total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);
-        require(total - ia.used >= _amount, 'SAL03');
+        require(ia.total - ia.used >= _amount, 'SAL03');
         ia.used += _amount;
         deploymentAllocations[_deployment] += _amount;
         allocatedTokens[_runner][_deployment] += _amount;
@@ -110,10 +109,9 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         // TODO: split to add and remove
         deploymentAllocations[_deployment] -= _amount;
         allocatedTokens[_runner][_deployment] -= _amount;
-        uint256 total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);
-        if (ia.overflowAt != 0 && total >= ia.used) {
+        if (ia.overflowAt != 0 && ia.total >= ia.used) {
             // collectAllocationReward had beed overflowClear, so just set overflowAt
-            emit StakeOverflowEnded(_runner, block.timestamp, block.timestamp - ia.overflowAt);
+            emit OverAllocationEnded(_runner, block.timestamp, block.timestamp - ia.overflowAt);
 
             ia.overflowAt = 0;
         }
@@ -128,9 +126,9 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     /**
      * @notice this returns the accumulated overflowTime of given runner
      */
-    function overflowTime(address _runner) external view returns (uint256) {
+    function overAllocationTime(address _runner) external view returns (uint256) {
         RunnerAllocation memory ia = _runnerAllocations[_runner];
-        if (isAllocationOverflow(_runner)) {
+        if (ia.total < ia.used) {
             return ia.overflowTime + block.timestamp - ia.overflowAt;
         } else {
             return ia.overflowTime;
@@ -138,8 +136,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     }
 
     function isAllocationOverflow(address _runner) public view returns (bool) {
-        uint256 total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);
-        return total < _runnerAllocations[_runner].used;
+        return _runnerAllocations[_runner].total < _runnerAllocations[_runner].used;
     }
 
     function _isAuth(address _runner) private view returns (bool) {

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -135,7 +135,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         }
     }
 
-    function isAllocationOverflow(address _runner) public view returns (bool) {
+    function isOverAllocation(address _runner) external view returns (bool) {
         return _runnerAllocations[_runner].total < _runnerAllocations[_runner].used;
     }
 

--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -11,7 +11,11 @@ import './interfaces/IStakingManager.sol';
 import './interfaces/IIndexerRegistry.sol';
 import './interfaces/IEraManager.sol';
 import './utils/StakingUtil.sol';
+import './utils/MathUtil.sol';
 
+/**
+ * Split from Staking, to keep contract size under control
+ */
 contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
 
     ISettings public settings;
@@ -53,13 +57,13 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
     /**
      * @dev Delegator stake to Indexer, Indexer cannot call this.
      */
-    function delegate(address _indexer, uint256 _amount) external {
-        require(msg.sender != _indexer, 'G004');
+    function delegate(address _runner, uint256 _amount) external {
+        require(msg.sender != _runner, 'G004');
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        staking.reflectEraUpdate(msg.sender, _indexer);
+        staking.reflectEraUpdate(msg.sender, _runner);
         // delegation limit should not exceed
-        staking.checkDelegateLimitation(_indexer, _amount);
-        staking.delegateToIndexer(msg.sender, _indexer, _amount);
+        staking.checkDelegateLimitation(_runner, _amount);
+        staking.delegateToIndexer(msg.sender, _runner, _amount);
     }
 
     /**
@@ -67,32 +71,33 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
      * the existential amount should be greater than minimum staking amount
      * If the caller is from IndexerRegistry, this function will unstake all the staking token for the indexer.
      */
-    function unstake(address _indexer, uint256 _amount) external {
+    function unstake(address _runner, uint256 _amount) external {
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        staking.reflectEraUpdate(_indexer, _indexer);
+        staking.reflectEraUpdate(_runner, _runner);
         if (msg.sender == settings.getContractAddress(SQContracts.IndexerRegistry)) {
-            staking.removeRunner(_indexer);
+            staking.removeRunner(_runner);
         } else {
-            require(msg.sender == _indexer, 'G002');
+            require(msg.sender == _runner, 'G002');
 
             uint256 minimumStakingAmount = IIndexerRegistry(settings.getContractAddress(SQContracts.IndexerRegistry)).minimumStakingAmount();
-            uint256 stakingAmountAfter = this.getAfterDelegationAmount(_indexer, _indexer) - _amount;
+            uint256 stakingAmountAfter = this.getAfterDelegationAmount(_runner, _runner) - _amount;
             require(stakingAmountAfter >= minimumStakingAmount, 'S008');
-            (,,uint256 totalStakingAmount) = staking.totalStakingAmount(_indexer);
-            require(stakingAmountAfter * staking.indexerLeverageLimit() >= totalStakingAmount - _amount, 'S008');
+            // allow self stake under the amount calculated by indexerLeverageLimit
+//            (,,uint256 totalStakingAmount) = staking.totalStakingAmount(_indexer);
+//            require(stakingAmountAfter * staking.indexerLeverageLimit() >= totalStakingAmount - _amount, 'S008');
         }
-        staking.startUnbond(_indexer, _indexer, _amount, UnbondType.Unstake);
+        staking.startUnbond(_runner, _runner, _amount, UnbondType.Unstake);
     }
 
     /**
      * @dev Request a unbond from an indexer for specific amount.
      */
-    function undelegate(address _indexer, uint256 _amount) external {
+    function undelegate(address _runner, uint256 _amount) external {
         // check if called by an indexer
-        require(_indexer != msg.sender, 'G004');
+        require(_runner != msg.sender, 'G004');
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        staking.reflectEraUpdate(msg.sender, _indexer);
-        staking.startUnbond(msg.sender, _indexer, _amount, UnbondType.Undelegation);
+        staking.reflectEraUpdate(msg.sender, _runner);
+        staking.startUnbond(msg.sender, _runner, _amount, UnbondType.Undelegation);
     }
 
     /**
@@ -100,20 +105,20 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
      * Indexer's self delegations are not allow to redelegate.
      */
     function redelegate(
-        address from_indexer,
-        address to_indexer,
+        address _fromRunner,
+        address _toRunner,
         uint256 _amount
     ) external {
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
         address _source = msg.sender;
-        require(from_indexer != msg.sender, 'G004');
+        require(_fromRunner != msg.sender, 'G004');
         // delegation limit should not exceed
-        staking.checkDelegateLimitation(to_indexer, _amount);
+        staking.checkDelegateLimitation(_toRunner, _amount);
 
-        staking.reflectEraUpdate(_source, from_indexer);
-        staking.removeDelegation(_source, from_indexer, _amount);
-        staking.reflectEraUpdate(_source, to_indexer);
-        staking.addDelegation(_source, to_indexer, _amount);
+        staking.reflectEraUpdate(_source, _fromRunner);
+        staking.removeDelegation(_source, _fromRunner, _amount);
+        staking.reflectEraUpdate(_source, _toRunner);
+        staking.addDelegation(_source, _toRunner, _amount);
     }
 
     function cancelUnbonding(uint256 unbondReqId) external {
@@ -164,17 +169,33 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
 
     // -- Views --
 
-    function getTotalStakingAmount(address _indexer) external view override returns (uint256) {
+    function _getCurrentDelegationAmount(address _source, address _runner, uint256 _currentEra) internal view returns (uint256) {
+        Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
+        (uint256 era, uint256 valueAt, uint256 valueAfter) = staking.delegation(_source, _runner);
+        StakingAmount memory sm = StakingAmount(era, valueAt, valueAfter);
+        return StakingUtil.currentStaking(sm, _currentEra);
+    }
+
+    function getTotalStakingAmount(address _runner) public view override returns (uint256) {
         uint256 eraNumber = IEraManager(settings.getContractAddress(SQContracts.EraManager)).eraNumber();
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        (uint256 era, uint256 valueAt, uint256 valueAfter) = staking.totalStakingAmount(_indexer);
+        (uint256 era, uint256 valueAt, uint256 valueAfter) = staking.totalStakingAmount(_runner);
         StakingAmount memory sm = StakingAmount(era, valueAt, valueAfter);
         return StakingUtil.currentStaking(sm, eraNumber);
     }
 
-    function getAfterDelegationAmount(address _source, address _indexer) external view override returns (uint256) {
+    function getEffectiveTotalStake(address _runner) external view override returns (uint256) {
+        uint256 eraNumber = IEraManager(settings.getContractAddress(SQContracts.EraManager)).eraNumber();
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        (,,uint256 amount) = staking.delegation(_source, _indexer);
+        uint256 totalStake = getTotalStakingAmount(_runner);
+        uint256 selfStake = _getCurrentDelegationAmount(_runner, _runner, eraNumber);
+        uint256 totalStakeCap = selfStake * staking.indexerLeverageLimit();
+        return MathUtil.min(totalStake, totalStakeCap);
+    }
+
+    function getAfterDelegationAmount(address _source, address _runner) external view override returns (uint256) {
+        Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
+        (,,uint256 amount) = staking.delegation(_source, _runner);
         return amount;
     }
 
@@ -186,21 +207,21 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
         uint256 i;
         uint256 latestWithdrawnLength = staking.withdrawnLength(_source);
         for (uint256 j = latestWithdrawnLength; j < latestWithdrawnLength + withdrawingLength; j++) {
-            (address indexer, uint256 amount, uint256 startTime) = staking.unbondingAmount(_source, j);
-            unbondAmounts[i] = UnbondAmount(indexer, amount, startTime);
+            (address runner, uint256 amount, uint256 startTime) = staking.unbondingAmount(_source, j);
+            unbondAmounts[i] = UnbondAmount(runner, amount, startTime);
             i++;
         }
 
         return unbondAmounts;
     }
 
-    function getSlashableAmount(address _indexer) external view returns (uint256) {
+    function getSlashableAmount(address _runner) external view returns (uint256) {
         Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
-        (,,uint256 slashableAmount) = staking.delegation(_indexer, _indexer);
-        uint256 withdrawingLength = staking.unbondingLength(_indexer) - staking.withdrawnLength(_indexer);
-        uint256 latestWithdrawnLength = staking.withdrawnLength(_indexer);
+        (,,uint256 slashableAmount) = staking.delegation(_runner, _runner);
+        uint256 withdrawingLength = staking.unbondingLength(_runner) - staking.withdrawnLength(_runner);
+        uint256 latestWithdrawnLength = staking.withdrawnLength(_runner);
         for (uint256 i = latestWithdrawnLength; i < latestWithdrawnLength + withdrawingLength; i++) {
-            (,uint256 amount,) = staking.unbondingAmount(_indexer, i);
+            (,uint256 amount,) = staking.unbondingAmount(_runner, i);
             slashableAmount += amount;
         }
         return slashableAmount;

--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -131,9 +131,9 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
         require(indexerRegistry.isIndexer(indexer), 'S007');
 
         staking.removeUnbondingAmount(msg.sender, unbondReqId);
-        if (msg.sender != indexer) {
-            staking.checkDelegateLimitation(indexer, amount);
-        }
+//        if (msg.sender != indexer) {
+//            staking.checkDelegateLimitation(indexer, amount);
+//        }
         staking.addDelegation(msg.sender, indexer, amount);
     }
 

--- a/contracts/interfaces/IStakingAllocation.sol
+++ b/contracts/interfaces/IStakingAllocation.sol
@@ -19,7 +19,7 @@ interface IStakingAllocation {
 
     function overAllocationTime(address _runner) external view returns (uint256);
 
-    function isAllocationOverflow(address _runner) external view returns (bool);
+    function isOverAllocation(address _runner) external view returns (bool);
 
     // total allocations on the deployment
     function deploymentAllocations(bytes32 _deploymentId) external view returns (uint256);

--- a/contracts/interfaces/IStakingAllocation.sol
+++ b/contracts/interfaces/IStakingAllocation.sol
@@ -4,7 +4,6 @@
 pragma solidity 0.8.15;
 
 struct RunnerAllocation {
-    uint256 total;
     uint256 used;
     uint256 overflowTime;
     uint256 overflowAt;
@@ -19,7 +18,7 @@ interface IStakingAllocation {
 
     function overflowTime(address _runner) external view returns (uint256);
 
-    function isSuspended(address _runner) external view returns (bool);
+    function isAllocationOverflow(address _runner) external view returns (bool);
 
     // total allocations on the deployment
     function deploymentAllocations(bytes32 _deploymentId) external view returns (uint256);

--- a/contracts/interfaces/IStakingAllocation.sol
+++ b/contracts/interfaces/IStakingAllocation.sol
@@ -4,6 +4,7 @@
 pragma solidity 0.8.15;
 
 struct RunnerAllocation {
+    uint256 total;
     uint256 used;
     uint256 overflowTime;
     uint256 overflowAt;
@@ -16,7 +17,7 @@ interface IStakingAllocation {
 
     function runnerAllocation(address _runner) external view returns (RunnerAllocation memory);
 
-    function overflowTime(address _runner) external view returns (uint256);
+    function overAllocationTime(address _runner) external view returns (uint256);
 
     function isAllocationOverflow(address _runner) external view returns (bool);
 

--- a/contracts/interfaces/IStakingManager.sol
+++ b/contracts/interfaces/IStakingManager.sol
@@ -12,5 +12,7 @@ interface IStakingManager {
 
     function getTotalStakingAmount(address _runner) external view returns (uint256);
 
+    function getEffectiveTotalStake(address _runner) external view returns (uint256);
+
     function getAfterDelegationAmount(address _delegator, address _runner) external view returns (uint256);
 }

--- a/contracts/utils/StakingUtil.sol
+++ b/contracts/utils/StakingUtil.sol
@@ -16,11 +16,4 @@ library StakingUtil {
         }
         return amount.valueAt;
     }
-
-    function currentDelegation(StakingAmount memory amount, uint256 era) internal pure returns (uint256) {
-        if (amount.era < era) {
-            return amount.valueAfter;
-        }
-        return amount.valueAt;
-    }
 }

--- a/publish/ABI/StakingAllocation.json
+++ b/publish/ABI/StakingAllocation.json
@@ -212,7 +212,7 @@
                 "type": "address"
             }
         ],
-        "name": "isAllocationOverflow",
+        "name": "isOverAllocation",
         "outputs": [
             {
                 "internalType": "bool",

--- a/publish/ABI/StakingAllocation.json
+++ b/publish/ABI/StakingAllocation.json
@@ -16,6 +16,50 @@
         "anonymous": false,
         "inputs": [
             {
+                "indexed": false,
+                "internalType": "address",
+                "name": "runner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "end",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "time",
+                "type": "uint256"
+            }
+        ],
+        "name": "OverAllocationEnded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "runner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "start",
+                "type": "uint256"
+            }
+        ],
+        "name": "OverAllocationStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
                 "indexed": true,
                 "internalType": "address",
                 "name": "previousOwner",
@@ -79,50 +123,6 @@
             }
         ],
         "name": "StakeAllocationRemoved",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "indexer",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "end",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "time",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakeOverflowEnded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "indexer",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "start",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakeOverflowStarted",
         "type": "event"
     },
     {
@@ -249,7 +249,7 @@
                 "type": "address"
             }
         ],
-        "name": "overflowTime",
+        "name": "overAllocationTime",
         "outputs": [
             {
                 "internalType": "uint256",
@@ -315,6 +315,11 @@
         "outputs": [
             {
                 "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "total",
+                        "type": "uint256"
+                    },
                     {
                         "internalType": "uint256",
                         "name": "used",

--- a/publish/ABI/StakingAllocation.json
+++ b/publish/ABI/StakingAllocation.json
@@ -212,7 +212,7 @@
                 "type": "address"
             }
         ],
-        "name": "isSuspended",
+        "name": "isAllocationOverflow",
         "outputs": [
             {
                 "internalType": "bool",
@@ -315,11 +315,6 @@
         "outputs": [
             {
                 "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "total",
-                        "type": "uint256"
-                    },
                     {
                         "internalType": "uint256",
                         "name": "used",

--- a/publish/ABI/StakingManager.json
+++ b/publish/ABI/StakingManager.json
@@ -48,7 +48,7 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
                 "type": "address"
             },
             {
@@ -71,7 +71,7 @@
             },
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
                 "type": "address"
             }
         ],
@@ -90,7 +90,26 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
+                "type": "address"
+            }
+        ],
+        "name": "getEffectiveTotalStake",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_runner",
                 "type": "address"
             }
         ],
@@ -109,7 +128,7 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
                 "type": "address"
             }
         ],
@@ -190,12 +209,12 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "from_indexer",
+                "name": "_fromRunner",
                 "type": "address"
             },
             {
                 "internalType": "address",
-                "name": "to_indexer",
+                "name": "_toRunner",
                 "type": "address"
             },
             {
@@ -295,7 +314,7 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
                 "type": "address"
             },
             {
@@ -313,7 +332,7 @@
         "inputs": [
             {
                 "internalType": "address",
-                "name": "_indexer",
+                "name": "_runner",
                 "type": "address"
             },
             {

--- a/test/RewardsBooster.test.ts
+++ b/test/RewardsBooster.test.ts
@@ -637,11 +637,11 @@ describe('RewardsBooster Contract', () => {
             expect(status1.overflowAt).not.to.eq(0);
             expect(status1.overflowTime).to.eq(0);
             await timeTravel(mockProvider, 10);
-            const overtime1 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime1 = await stakingAllocation.overAllocationTime(runner0.address);
 
             // collect when overflow
             await rewardsBooster.connect(runner0).collectAllocationReward(deploymentIds[0], runner0.address);
-            const overtime2 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime2 = await stakingAllocation.overAllocationTime(runner0.address);
             expect(overtime2).to.gt(overtime1);
             const rewards2 = await rewardsBooster.getRunnerDeploymentRewards(deploymentIds[0], runner0.address);
             expect(rewards2.overflowTimeSnapshot).to.eq(overtime2);
@@ -651,7 +651,7 @@ describe('RewardsBooster Contract', () => {
             await timeTravel(mockProvider, 10);
             await stakingManager.connect(runner0).stake(runner0.address, etherParse('5000'));
             await applyStaking(runner0, runner0);
-            const overtime3 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime3 = await stakingAllocation.overAllocationTime(runner0.address);
             expect(overtime3).to.gt(overtime2);
             const status3 = await stakingAllocation.runnerAllocation(runner0.address);
             expect(status3.overflowAt).to.eq(0);
@@ -670,7 +670,7 @@ describe('RewardsBooster Contract', () => {
             await timeTravel(mockProvider, 10);
             await stakingManager.connect(runner0).stake(runner0.address, etherParse('5000'));
             await applyStaking(runner0, runner0);
-            const overtime4 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime4 = await stakingAllocation.overAllocationTime(runner0.address);
             const status4 = await stakingAllocation.runnerAllocation(runner0.address);
             expect(status4.overflowAt).to.eq(0);
             expect(status4.overflowTime).to.gt(overtime3);

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -166,7 +166,8 @@ describe('Staking Contract', () => {
             ).to.be.revertedWith('S008');
         });
 
-        it('unstaking over indexerLeverageLimit should fail', async () => {
+        // it is allowed now
+        it.skip('unstaking over indexerLeverageLimit should fail', async () => {
             const indexerLeverageLimit = await staking.indexerLeverageLimit();
             const indexerStakingAmount = await stakingManager.getAfterDelegationAmount(
                 runner.address,

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -478,7 +478,8 @@ describe('Staking Contract', () => {
             await expect(stakingManager.connect(delegator).cancelUnbonding(10)).to.be.revertedWith('S007');
         });
 
-        it('cancelUnbonding should follow delegation limitation', async () => {
+        // this is allowed now
+        it.skip('cancelUnbonding should follow delegation limitation', async () => {
             await stakingManager.connect(delegator).undelegate(runner.address, etherParse('1'));
             await staking.setIndexerLeverageLimit(1);
             await expect(stakingManager.connect(delegator).cancelUnbonding(0)).to.be.revertedWith('S002');

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -63,7 +63,7 @@ describe('StakingAllocation Contract', () => {
 
     const checkAllocation = async (runner, total, used, isOverflow, hasOverfloatTime) => {
         const status = await stakingAllocation.runnerAllocation(runner.address);
-        // expect(status.total).to.eq(total);
+        expect(status.total).to.eq(total);
         expect(status.used).to.eq(used);
         if (isOverflow) {
             expect(status.overflowAt).not.to.eq(0);
@@ -164,7 +164,7 @@ describe('StakingAllocation Contract', () => {
             await checkAllocation(runner0, etherParse('10000'), etherParse('20000'), true, false);
 
             await timeTravel(mockProvider, 10);
-            const overtime = await stakingAllocation.overflowTime(runner0.address);
+            const overtime = await stakingAllocation.overAllocationTime(runner0.address);
             if (overtime.lt(10)) {
                 expect('overtime').to.eq('shuould more than it');
             }
@@ -173,12 +173,12 @@ describe('StakingAllocation Contract', () => {
             await applyStaking(runner0, runner1);
 
             await checkAllocation(runner0, etherParse('20000'), etherParse('20000'), false, true);
-            const overtime1 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime1 = await stakingAllocation.overAllocationTime(runner0.address);
             if (overtime1.lt(10)) {
                 expect('overtime').to.eq('shuould more than it');
             }
             await timeTravel(mockProvider, 10);
-            const overtime2 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime2 = await stakingAllocation.overAllocationTime(runner0.address);
             expect(overtime1).to.eq(overtime2);
 
             await stakingManager.connect(runner1).undelegate(runner0.address, etherParse('1'));
@@ -186,7 +186,7 @@ describe('StakingAllocation Contract', () => {
 
             await checkAllocation(runner0, etherParse('19999'), etherParse('20000'), true, true);
             await timeTravel(mockProvider, 10);
-            const overtime3 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime3 = await stakingAllocation.overAllocationTime(runner0.address);
             if (overtime3.lt(overtime2.add(10))) {
                 expect('overtime').to.eq('shuould more than it');
             }
@@ -194,10 +194,10 @@ describe('StakingAllocation Contract', () => {
             await stakingManager.connect(runner1).delegate(runner0.address, etherParse('101'));
             await applyStaking(runner0, runner1);
             await checkAllocation(runner0, etherParse('20100'), etherParse('20000'), false, true);
-            const overtime4 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime4 = await stakingAllocation.overAllocationTime(runner0.address);
 
             await timeTravel(mockProvider, 10);
-            const overtime5 = await stakingAllocation.overflowTime(runner0.address);
+            const overtime5 = await stakingAllocation.overAllocationTime(runner0.address);
             expect(overtime4).to.eq(overtime5);
         });
         it('add/del allocation', async () => {

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -63,7 +63,7 @@ describe('StakingAllocation Contract', () => {
 
     const checkAllocation = async (runner, total, used, isOverflow, hasOverfloatTime) => {
         const status = await stakingAllocation.runnerAllocation(runner.address);
-        expect(status.total).to.eq(total);
+        // expect(status.total).to.eq(total);
         expect(status.used).to.eq(used);
         if (isOverflow) {
             expect(status.overflowAt).not.to.eq(0);


### PR DESCRIPTION
Currently, when runner call `unstake()` we check if the new total stake is below what's allowed as calculated via `indexerLeverageLimit`. 
It brings a problem, that runners are not free to unstake anymore unless they convince their delegators to reduce delegation, or they completely exit from runner role.

In this PR, we allow runner unstake even the afterwards total stake is below what indexerLeverageLimit allows, with several consequences
* in reward pool calculation, we use runner's effectiveTotalStake instead of totalStake
* in allocation reward calculation, we use runner's effectiveTotalStake instead of totalStake

effectiveTotalStake = Min( totalStake, selfStake * indexerLeverageLimit)