### PR TITLE
pass channelId to QueryRewardsSpent & QueryRewardsRefunded

### DIFF
--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -74,8 +74,8 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
     event MissedLabor(bytes32 indexed deploymentId, address indexed runner, uint256 labor);
     event AllocationRewardsGiven(bytes32 indexed deploymentId, address indexed runner, uint256 amount);
     event AllocationRewardsBurnt(bytes32 indexed deploymentId, address indexed runner, uint256 amount);
-    event QueryRewardsSpent(bytes32 indexed deploymentId, address indexed runner, uint256 amount);
-    event QueryRewardsRefunded(bytes32 indexed deploymentId, address indexed runner, uint256 amount);
+    event QueryRewardsSpent(bytes32 indexed deploymentId, address indexed runner, uint256 amount, bytes data);
+    event QueryRewardsRefunded(bytes32 indexed deploymentId, address indexed runner, uint256 amount, bytes data);
 
     /**
      * @notice ### FUNCTIONS
@@ -562,7 +562,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
         return deploymentPools[_deploymentId].runnerAllocationRewards[_account];
     }
 
-    function spendQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount) external returns (uint256) {
+    function spendQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount, bytes calldata _data) override external returns (uint256) {
         require(msg.sender == settings.getContractAddress(SQContracts.StateChannel), 'RB01');
         uint256 queryRewards = getQueryRewards(_deploymentId, _spender);
 
@@ -579,11 +579,11 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
         // Allowance
         IERC20(settings.getContractAddress(SQContracts.SQToken)).approve(msg.sender, _amount);
 
-        emit QueryRewardsSpent(_deploymentId, _spender, _amount);
+        emit QueryRewardsSpent(_deploymentId, _spender, _amount, _data);
         return _amount;
     }
 
-    function refundQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount) external {
+    function refundQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount, bytes calldata _data) override external {
         require(msg.sender == settings.getContractAddress(SQContracts.StateChannel), 'RB01');
 
         DeploymentPool storage deployment = deploymentPools[_deploymentId];
@@ -593,6 +593,6 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
 
         IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransfer(ISettings(settings).getContractAddress(SQContracts.Treasury), _amount);
 
-        emit QueryRewardsRefunded(_deploymentId, _spender, _amount);
+        emit QueryRewardsRefunded(_deploymentId, _spender, _amount, _data);
     }
 }

--- a/contracts/StateChannel.sol
+++ b/contracts/StateChannel.sol
@@ -259,7 +259,7 @@ contract StateChannel is Initializable, OwnableUpgradeable {
 
         // transfer the rewards to channel
         address rbAddress = settings.getContractAddress(SQContracts.RewardsBooster);
-        uint256 rewardsAmount = IRewardsBooster(rbAddress).spendQueryRewards(channels[channelId].deploymentId, realConsumer, amount);
+        uint256 rewardsAmount = IRewardsBooster(rbAddress).spendQueryRewards(channels[channelId].deploymentId, realConsumer, amount, abi.encode(channelId));
         if (rewardsAmount > 0) {
             IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransferFrom(rbAddress, address(this), rewardsAmount);
         }
@@ -486,7 +486,7 @@ contract StateChannel is Initializable, OwnableUpgradeable {
                 uint256 rewardsRemain = remain - realTotal;
                 address rbAddress = settings.getContractAddress(SQContracts.RewardsBooster);
                 IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransfer(rbAddress, rewardsRemain);
-                IRewardsBooster(rbAddress).refundQueryRewards(channels[channelId].deploymentId, realConsumer, rewardsRemain);
+                IRewardsBooster(rbAddress).refundQueryRewards(channels[channelId].deploymentId, realConsumer, rewardsRemain, abi.encode(channelId));
 
                 realRemain = realTotal;
             }

--- a/contracts/interfaces/IRewardsBooster.sol
+++ b/contracts/interfaces/IRewardsBooster.sol
@@ -73,7 +73,7 @@ interface IRewardsBooster {
 
     function collectAllocationReward(bytes32 _deploymentId, address _runner) external;
 
-    function spendQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount) external returns (uint256);
+    function spendQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount, bytes calldata data) external returns (uint256);
 
-    function refundQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount) external;
+    function refundQueryRewards(bytes32 _deploymentId, address _spender, uint256 _amount, bytes calldata data) external;
 }

--- a/publish/ABI/RewardsBooster.json
+++ b/publish/ABI/RewardsBooster.json
@@ -189,6 +189,12 @@
                 "internalType": "uint256",
                 "name": "amount",
                 "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
             }
         ],
         "name": "QueryRewardsRefunded",
@@ -214,6 +220,12 @@
                 "internalType": "uint256",
                 "name": "amount",
                 "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
             }
         ],
         "name": "QueryRewardsSpent",
@@ -764,6 +776,11 @@
                 "internalType": "uint256",
                 "name": "_amount",
                 "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
             }
         ],
         "name": "refundQueryRewards",
@@ -929,6 +946,11 @@
                 "internalType": "uint256",
                 "name": "_amount",
                 "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
             }
         ],
         "name": "spendQueryRewards",


### PR DESCRIPTION
Pass channelId to QueryRewardsSpent & QueryRewardsRefunded
So we can know which runner the query rewards was spent on.