### PR TITLE
consumer host fee rate change to perMill

### DIFF
--- a/scripts/config/contracts.config.ts
+++ b/scripts/config/contracts.config.ts
@@ -11,7 +11,7 @@ export default {
         ServiceAgreementExtra: [1e6], //threshold
         PurchaseOfferMarket: [1e5, '0x34c35136ECe9CBD6DfDf2F896C6e29be01587c0C'],
         IndexerRegistry: [utils.parseEther("16000")],
-        ConsumerHost: [1], // Fee Percentage, default is 1%
+        ConsumerHost: [10000], // Fee Percentage, default is 1%
         DisputeManager: [utils.parseEther("10000")], // minimumDeposit
     },
     kepler: {
@@ -66,7 +66,7 @@ export default {
         ServiceAgreementExtra: [1e6], //threshold
         PurchaseOfferMarket: [1e5, '0x0000000000000000000000000000000000000000'],
         IndexerRegistry: [utils.parseEther("1000")],
-        ConsumerHost: [1], // Fee Percentage, default is 1%
+        ConsumerHost: [10000], // Fee Percentage, default is 1%
         DisputeManager: [utils.parseEther("10000")], // minimumDeposit
         // polygon: 10240000 blocks a year, 1% rewards = about 9.5 SQT per block
         RewardsBooster: [utils.parseEther("9.5"), utils.parseEther("10000")], // _issuancePerBlock, _minimumDeploymentBooster

--- a/test/ConsumerHost.test.ts
+++ b/test/ConsumerHost.test.ts
@@ -299,6 +299,7 @@ describe('ConsumerHost Contract', () => {
                 60,
                 false
             );
+            const fee = await consumerHost.feePerMill();
             expect((await consumerHost.consumers(consumer.address)).balance).to.equal(etherParse('8.99')); // 10 - 1 - 0.01
             expect(await consumerHost.channels(channelId)).to.equal(consumer.address);
 
@@ -335,8 +336,8 @@ describe('ConsumerHost Contract', () => {
             // update fee from 1% ~ 2%
             const fee1 = await consumerHost.fee();
             expect(fee1).to.equal(etherParse('0.04')); // 0.01 + 0.02 + 0.01
-            await consumerHost.connect(wallet_0).setFeePercentage(BigNumber.from(2));
-            await expect(consumerHost.connect(wallet_0).setFeePercentage(BigNumber.from(101))).to.be.revertedWith(
+            await consumerHost.connect(wallet_0).setFeeRate(BigNumber.from(20000));
+            await expect(consumerHost.connect(wallet_0).setFeeRate(BigNumber.from(1010000))).to.be.revertedWith(
                 'C001'
             );
             await fundChannel(

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -26,7 +26,7 @@ export const deployContracts = async (wallet: Wallet, wallet1: Wallet, treasury=
             // ServiceAgreementExtra: [1e6],
             PurchaseOfferMarket: [1e5, ZERO_ADDRESS],
             IndexerRegistry: [etherParse("1000").toString()],
-            ConsumerHost: [1],
+            ConsumerHost: [10000],
             DisputeManager: [etherParse("1000").toString()],
             Settings: [],
             VSQToken: [],


### PR DESCRIPTION
for consistency and better precision, use preMill (1e6) for consumer host fee.