### PR TITLE
Remove `_amount` param in `onStakeUpdate`

### DIFF
--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -141,7 +141,7 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
 
             // notify stake allocation
             IStakingAllocation stakingAllocation = IStakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation));
-            stakingAllocation.onStakeUpdate(_indexer, totalStakingAmount[_indexer]);
+            stakingAllocation.onStakeUpdate(_indexer);
         } else {
             require(rewardsDistributor.collectAndDistributeEraRewards(currentEra, _indexer) == currentEra - 1, 'RS002');
             IndexerRewardInfo memory rewardInfo = rewardsDistributor.getRewardInfo(_indexer);
@@ -208,7 +208,7 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
 
         // notify stake allocation
         IStakingAllocation stakingAllocation = IStakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation));
-        stakingAllocation.onStakeUpdate(indexer, totalStakingAmount[indexer]);
+        stakingAllocation.onStakeUpdate(indexer);
     }
 
     /**

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -60,7 +60,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         settings = _settings;
     }
 
-    function onStakeUpdate(address _runner, uint256 _amount) external {
+    function onStakeUpdate(address _runner) external {
         require(msg.sender == settings.getContractAddress(SQContracts.RewardsStaking), 'SAL01');
         RunnerAllocation storage ia = _runnerAllocations[_runner];
         ia.total = IStakingManager(settings.getContractAddress(SQContracts.StakingManager)).getEffectiveTotalStake(_runner);

--- a/contracts/interfaces/IStakingAllocation.sol
+++ b/contracts/interfaces/IStakingAllocation.sol
@@ -11,7 +11,7 @@ struct RunnerAllocation {
 }
 
 interface IStakingAllocation {
-    function onStakeUpdate(address _runner, uint256 _amount) external;
+    function onStakeUpdate(address _runner) external;
 
     function allocatedTokens(address _runner, bytes32 _deployment) external view returns (uint256);
 

--- a/publish/ABI/ConsumerHost.json
+++ b/publish/ABI/ConsumerHost.json
@@ -460,7 +460,7 @@
     },
     {
         "inputs": [],
-        "name": "feePercentage",
+        "name": "feePerMill",
         "outputs": [
             {
                 "internalType": "uint256",
@@ -503,7 +503,7 @@
             },
             {
                 "internalType": "uint256",
-                "name": "_feePercentage",
+                "name": "_feePerMill",
                 "type": "uint256"
             }
         ],
@@ -616,11 +616,11 @@
         "inputs": [
             {
                 "internalType": "uint256",
-                "name": "_feePercentage",
+                "name": "_feePerMill",
                 "type": "uint256"
             }
         ],
-        "name": "setFeePercentage",
+        "name": "setFeeRate",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/ABI/StakingAllocation.json
+++ b/publish/ABI/StakingAllocation.json
@@ -229,11 +229,6 @@
                 "internalType": "address",
                 "name": "_runner",
                 "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
             }
         ],
         "name": "onStakeUpdate",


### PR DESCRIPTION
## Changes

- Remove `_amount` from `onStakeUpdate` as it is unused when switch to get indexerTotalStaking from separate function
- Update `/publish/abi` which the change introduce in previous PR