### PR TITLE
Resolve cycle dependency between `StakingAllocation` and `RewardBooster`

### DIFF
--- a/contracts/AllocationManager.sol
+++ b/contracts/AllocationManager.sol
@@ -1,0 +1,79 @@
+// Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.15;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+import './interfaces/ISettings.sol';
+import './interfaces/IRewardsBooster.sol';
+import './interfaces/IIndexerRegistry.sol';
+import './Constants.sol';
+import './StakingAllocation.sol';
+import './utils/MathUtil.sol';
+
+/**
+ * @title Staking Allocation Mananger Contract
+ * @notice ### Overview
+ * Staking Allocation Mananger Contract provides the functionality to manage the staking allocation.
+ */
+contract AllocationMananger is Initializable, OwnableUpgradeable {
+    using SafeERC20 for IERC20;
+    using MathUtil for uint256;
+
+    // -- Storage --
+    ISettings public settings;
+
+    // -- Functions --
+
+    /**
+     * @dev Initialize this contract.
+     */
+    function initialize(ISettings _settings) external initializer {
+        __Ownable_init();
+
+        settings = _settings;
+    }
+
+    function setSettings(ISettings _settings) external onlyOwner {
+        settings = _settings;
+    }
+
+    function addAllocation(bytes32 _deployment, address _runner, uint256 _amount) external {
+        require(_isAuth(_runner), 'SAL02');
+
+        // collect rewards (if any) before change allocation
+        IRewardsBooster rb = IRewardsBooster(
+            settings.getContractAddress(SQContracts.RewardsBooster)
+        );
+        rb.collectAllocationReward(_deployment, _runner);
+        StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation)).addAllocation(_deployment, _runner, _amount);
+    }
+
+    function removeAllocation(bytes32 _deployment, address _runner, uint256 _amount) external {
+        require(_isAuth(_runner), 'SAL02');
+
+        StakingAllocation sa = StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation));
+        require(sa.allocatedTokens[_runner][_deployment] >= _amount, 'SAL04');
+
+        // collect rewards (if any) before change allocation
+        IRewardsBooster rb = IRewardsBooster(
+            settings.getContractAddress(SQContracts.RewardsBooster)
+        );
+        rb.collectAllocationReward(_deployment, _runner);
+
+        sa.removeAllocation(_deployment, _runner, _amount);
+    }
+
+    function _isAuth(address _runner) private view returns (bool) {
+        IIndexerRegistry indexerRegistry = IIndexerRegistry(
+            ISettings(settings).getContractAddress(SQContracts.IndexerRegistry)
+        );
+
+        address controller = indexerRegistry.getController(_runner);
+        return msg.sender == _runner || msg.sender == controller;
+    }
+}

--- a/contracts/AllocationManager.sol
+++ b/contracts/AllocationManager.sol
@@ -9,9 +9,7 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import './interfaces/ISettings.sol';
 import './interfaces/IRewardsBooster.sol';
 import './interfaces/IIndexerRegistry.sol';
-import './Constants.sol';
 import './StakingAllocation.sol';
-import './utils/MathUtil.sol';
 
 /**
  * @title Staking Allocation Mananger Contract

--- a/contracts/AllocationManager.sol
+++ b/contracts/AllocationManager.sol
@@ -57,7 +57,7 @@ contract AllocationMananger is Initializable, OwnableUpgradeable {
         require(_isAuth(_runner), 'SAL02');
 
         StakingAllocation sa = StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation));
-        require(sa.allocatedTokens[_runner][_deployment] >= _amount, 'SAL04');
+        require(sa.allocatedTokens(_runner, _deployment) >= _amount, 'SAL04');
 
         // collect rewards (if any) before change allocation
         IRewardsBooster rb = IRewardsBooster(

--- a/contracts/AllocationManager.sol
+++ b/contracts/AllocationManager.sol
@@ -50,13 +50,19 @@ contract AllocationMananger is Initializable, OwnableUpgradeable {
             settings.getContractAddress(SQContracts.RewardsBooster)
         );
         rb.collectAllocationReward(_deployment, _runner);
-        StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation)).addAllocation(_deployment, _runner, _amount);
+        StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation)).addAllocation(
+            _deployment,
+            _runner,
+            _amount
+        );
     }
 
     function removeAllocation(bytes32 _deployment, address _runner, uint256 _amount) external {
         require(_isAuth(_runner), 'SAL02');
 
-        StakingAllocation sa = StakingAllocation(settings.getContractAddress(SQContracts.StakingAllocation));
+        StakingAllocation sa = StakingAllocation(
+            settings.getContractAddress(SQContracts.StakingAllocation)
+        );
         require(sa.allocatedTokens(_runner, _deployment) >= _amount, 'SAL04');
 
         // collect rewards (if any) before change allocation

--- a/contracts/AllocationManager.sol
+++ b/contracts/AllocationManager.sol
@@ -3,8 +3,6 @@
 
 pragma solidity 0.8.15;
 
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 
@@ -21,9 +19,6 @@ import './utils/MathUtil.sol';
  * Staking Allocation Mananger Contract provides the functionality to manage the staking allocation.
  */
 contract AllocationMananger is Initializable, OwnableUpgradeable {
-    using SafeERC20 for IERC20;
-    using MathUtil for uint256;
-
     // -- Storage --
     ISettings public settings;
 

--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -506,7 +506,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
     function collectAllocationReward(bytes32 _deploymentId, address _runner) external override {
         require(
             msg.sender == _runner ||
-                msg.sender == settings.getContractAddress(SQContracts.StakingAllocation),
+                msg.sender == settings.getContractAddress(SQContracts.AllocationManager),
             'not allowed'
         );
         _collectAllocationReward(_deploymentId, _runner);

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -36,7 +36,6 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     // total allocation on the deployment
     mapping(bytes32 => uint256) public deploymentAllocations;
 
-
     // -- Events --
     event StakeAllocationAdded(bytes32 deploymentId, address runner, uint256 amount);
     event StakeAllocationRemoved(bytes32 deploymentId, address runner, uint256 amount);
@@ -57,7 +56,6 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     function setSettings(ISettings _settings) external onlyOwner {
         settings = _settings;
     }
-
 
     modifier onlyAllocationManager() {
         require(msg.sender == settings.getContractAddress(SQContracts.AllocationManager), 'SAL06');
@@ -85,7 +83,11 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         }
     }
 
-    function addAllocation(bytes32 _deployment, address _runner, uint256 _amount) external onlyAllocationManager {
+    function addAllocation(
+        bytes32 _deployment,
+        address _runner,
+        uint256 _amount
+    ) external onlyAllocationManager {
         RunnerAllocation storage ia = _runnerAllocations[_runner];
         require(ia.total - ia.used >= _amount, 'SAL03');
         ia.used += _amount;
@@ -95,7 +97,11 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         emit StakeAllocationAdded(_deployment, _runner, _amount);
     }
 
-    function removeAllocation(bytes32 _deployment, address _runner, uint256 _amount) external onlyAllocationManager {
+    function removeAllocation(
+        bytes32 _deployment,
+        address _runner,
+        uint256 _amount
+    ) external onlyAllocationManager {
         RunnerAllocation storage ia = _runnerAllocations[_runner];
         ia.used -= _amount;
         if (ia.overflowAt != 0 && ia.total >= ia.used) {

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -3,8 +3,6 @@
 
 pragma solidity 0.8.15;
 
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 
@@ -20,9 +18,6 @@ import './utils/MathUtil.sol';
  * The staking allocated by indexer to different projects(deployments)
  */
 contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradeable {
-    using SafeERC20 for IERC20;
-    using MathUtil for uint256;
-
     // -- Storage --
     ISettings public settings;
 

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -60,7 +60,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
 
 
     modifier onlyAllocationManager() {
-        require(msg.sender == settings.getContractAddress(SQContracts.AllocationManager), 'SAL009');
+        require(msg.sender == settings.getContractAddress(SQContracts.AllocationManager), 'SAL06');
         _;
     }
 

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -9,8 +9,6 @@ import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import './interfaces/IStakingManager.sol';
 import './interfaces/ISettings.sol';
 import './interfaces/IStakingAllocation.sol';
-import './Constants.sol';
-import './utils/MathUtil.sol';
 
 /**
  * @title Staking Allocation Contract
@@ -18,17 +16,18 @@ import './utils/MathUtil.sol';
  * The staking allocated by indexer to different projects(deployments)
  */
 contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradeable {
-    // -- Storage --
+    /// @dev ### STATES
+    /// @notice ISettings contract which stores SubQuery network contracts address
     ISettings public settings;
 
-    // The idle staking need allocated to projects
+    /// @notice The idle staking need allocated to projects
     mapping(address => RunnerAllocation) private _runnerAllocations;
 
-    // The staking allocated by runner to different projects(deployments)
-    // runner => deployment => amount
+    /// @notice The staking allocated by runner to different projects(deployments)
+    /// @notice runner => deployment => amount
     mapping(address => mapping(bytes32 => uint256)) public allocatedTokens;
 
-    // total allocation on the deployment
+    /// @notice total allocation on the deployment
     mapping(bytes32 => uint256) public deploymentAllocations;
 
     // -- Events --

--- a/contracts/interfaces/ISettings.sol
+++ b/contracts/interfaces/ISettings.sol
@@ -24,7 +24,8 @@ enum SQContracts {
     PriceOracle,
     Treasury,
     RewardsBooster,
-    StakingAllocation
+    StakingAllocation,
+    AllocationManager
 }
 
 interface ISettings {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -361,10 +361,19 @@ task('publishChild', 'verify and publish contracts on etherscan')
             //StakingAllocation
             await hre.run('verify:verify', {
                 address: deployment.StakingAllocation.address,
-                constructorArguments: [deployment.StakingAllocation.innerAddress, deployment.ProxyAdmin.address, []],
+                constructorArguments: [deployment.AllocationMananger.innerAddress, deployment.ProxyAdmin.address, []],
             });
             await hre.run('verify:verify', {
                 address: deployment.StakingAllocation.innerAddress,
+                constructorArguments: [],
+            });
+            //AllocationMananger
+            await hre.run('verify:verify', {
+                address: deployment.AllocationMananger.address,
+                constructorArguments: [deployment.AllocationMananger.innerAddress, deployment.ProxyAdmin.address, []],
+            });
+            await hre.run('verify:verify', {
+                address: deployment.AllocationMananger.innerAddress,
                 constructorArguments: [],
             });
         } catch (err) {

--- a/publish/revertcode.json
+++ b/publish/revertcode.json
@@ -198,6 +198,7 @@
     "SAL03": "Not enough staked token",
     "SAL04": "Not enough allocated token",
     "SAL05": "Can only be called by RewardsBooster",
+    "SAL06": "Can only be called by AllocationManager",
     "RB02": "Query refund can not be larger than spent",
     "OPD01": "l2token address is empty"
 }

--- a/scripts/abi.ts
+++ b/scripts/abi.ts
@@ -10,6 +10,7 @@ const main = async () => {
             'Staking',
             'StakingManager',
             'StakingAllocation',
+            'AllocationMananger',
             'IndexerRegistry',
             'ProjectRegistry',
             'PlanManager',

--- a/scripts/contracts.ts
+++ b/scripts/contracts.ts
@@ -53,6 +53,8 @@ import {
     StakingManager__factory,
     StakingAllocation,
     StakingAllocation__factory,
+    AllocationMananger,
+    AllocationMananger__factory,
     StateChannel,
     StateChannel__factory,
     VSQToken,
@@ -81,6 +83,7 @@ export type Contracts = {
     staking: Staking;
     stakingManager: StakingManager;
     stakingAllocation: StakingAllocation;
+    allocationMananger: AllocationMananger;
     eraManager: EraManager;
     indexerRegistry: IndexerRegistry;
     projectRegistry: ProjectRegistry;
@@ -123,6 +126,7 @@ export const UPGRADEBAL_CONTRACTS: Partial<
     Staking: [CONTRACTS.Staking, Staking__factory],
     StakingManager: [CONTRACTS.StakingManager, StakingManager__factory],
     StakingAllocation: [CONTRACTS.StakingAllocation, StakingAllocation__factory],
+    AllocationManager: [CONTRACTS.AllocationManager, AllocationMananger__factory],
     EraManager: [CONTRACTS.EraManager, EraManager__factory],
     PurchaseOfferMarket: [CONTRACTS.PurchaseOfferMarket, PurchaseOfferMarket__factory],
     StateChannel: [CONTRACTS.StateChannel, StateChannel__factory],
@@ -147,6 +151,7 @@ export const CONTRACT_FACTORY: Record<ContractName, FactoryContstructor> = {
     Staking: Staking__factory,
     StakingManager: StakingManager__factory,
     StakingAllocation: StakingAllocation__factory,
+    AllocationManager: AllocationMananger__factory,
     EraManager: EraManager__factory,
     IndexerRegistry: IndexerRegistry__factory,
     ProjectRegistry: ProjectRegistry__factory,

--- a/scripts/contracts.ts
+++ b/scripts/contracts.ts
@@ -83,7 +83,7 @@ export type Contracts = {
     staking: Staking;
     stakingManager: StakingManager;
     stakingAllocation: StakingAllocation;
-    allocationMananger: AllocationMananger;
+    allocationManager: AllocationMananger;
     eraManager: EraManager;
     indexerRegistry: IndexerRegistry;
     projectRegistry: ProjectRegistry;

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -564,6 +564,7 @@ export async function deployContracts(
                 sqtRedeem,
                 airdropper,
                 stakingAllocation,
+                allocationMananger,
             },
         ];
     } catch (error) {

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -479,7 +479,7 @@ export async function deployContracts(
         });
 
         // deploy StakingAllocation contract
-        const allocationMananger = await deployContract<AllocationMananger>('AllocationManager', 'child', {
+        const allocationManager = await deployContract<AllocationMananger>('AllocationManager', 'child', {
             proxyAdmin,
             initConfig: [settingsAddress],
         });
@@ -527,7 +527,7 @@ export async function deployContracts(
                 consumerRegistry.address,
                 rewardsBooster.address,
                 stakingAllocation.address,
-                allocationMananger.address,
+                allocationManager.address,
             ]
         );
 
@@ -564,7 +564,7 @@ export async function deployContracts(
                 sqtRedeem,
                 airdropper,
                 stakingAllocation,
-                allocationMananger,
+                allocationManager,
             },
         ];
     } catch (error) {

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -53,6 +53,7 @@ import {
     VTSQToken,
     RewardsBooster,
     StakingAllocation,
+    AllocationMananger,
     L2SQToken,
 } from '../src';
 import { CONTRACT_FACTORY, Config, ContractConfig, Contracts, UPGRADEBAL_CONTRACTS } from './contracts';
@@ -477,6 +478,13 @@ export async function deployContracts(
             initConfig: [settingsAddress],
         });
 
+
+        // deploy StakingAllocation contract
+        const allocationMananger = await deployContract<AllocationMananger>('AllocationManager', 'child', {
+            proxyAdmin,
+            initConfig: [settingsAddress],
+        });
+
         // Register addresses on settings contract
         logger?.info('🤞 Set settings addresses');
         const txToken = await settings.setBatchAddress(
@@ -499,6 +507,7 @@ export async function deployContracts(
                 SQContracts.ConsumerRegistry,
                 SQContracts.RewardsBooster,
                 SQContracts.StakingAllocation,
+                SQContracts.AllocationMananger,
             ],
             [
                 sqtToken.address,
@@ -519,6 +528,7 @@ export async function deployContracts(
                 consumerRegistry.address,
                 rewardsBooster.address,
                 stakingAllocation.address,
+                allocationMananger.address,
             ]
         );
 
@@ -539,7 +549,6 @@ export async function deployContracts(
                 planManager,
                 purchaseOfferMarket,
                 serviceAgreementRegistry,
-                // serviceAgreementExtra,
                 rewardsDistributor,
                 rewardsPool,
                 rewardsStaking,

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -478,7 +478,6 @@ export async function deployContracts(
             initConfig: [settingsAddress],
         });
 
-
         // deploy StakingAllocation contract
         const allocationMananger = await deployContract<AllocationMananger>('AllocationManager', 'child', {
             proxyAdmin,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,4 +1,3 @@
-import { AllocationMananger } from './typechain/contracts/AllocationManager.sol/AllocationMananger';
 // Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,3 +1,4 @@
+import { AllocationMananger } from './typechain/contracts/AllocationManager.sol/AllocationMananger';
 // Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,6 +27,7 @@ import Settings from './artifacts/contracts/Settings.sol/Settings.json';
 import Staking from './artifacts/contracts/Staking.sol/Staking.json';
 import StakingManager from './artifacts/contracts/StakingManager.sol/StakingManager.json';
 import StakingAllocation from './artifacts/contracts/StakingAllocation.sol/StakingAllocation.json';
+import AllocationManager from './artifacts/contracts/AllocationManager.sol/AllocationMananger.json';
 import StateChannel from './artifacts/contracts/StateChannel.sol/StateChannel.json';
 import VSQToken from './artifacts/contracts/VSQToken.sol/VSQToken.json';
 import Vesting from './artifacts/contracts/root/Vesting.sol/Vesting.json';
@@ -42,6 +44,7 @@ export default {
     Staking,
     StakingManager,
     StakingAllocation,
+    AllocationManager,
     IndexerRegistry,
     ProjectRegistry,
     InflationController,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { AllocationMananger } from './typechain/contracts/AllocationManager.sol/AllocationMananger';
 // Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,6 +41,7 @@ import {
     SQTRedeem__factory,
     RewardsBooster__factory,
     StakingAllocation__factory,
+    AllocationMananger__factory,
     L2SQToken__factory,
 } from './typechain';
 
@@ -111,6 +113,7 @@ export const CONTRACT_FACTORY: Record<ContractName, FactoryContstructor> = {
     Staking: Staking__factory,
     StakingManager: StakingManager__factory,
     StakingAllocation: StakingAllocation__factory,
+    AllocationManager: AllocationMananger__factory,
     EraManager: EraManager__factory,
     IndexerRegistry: IndexerRegistry__factory,
     ProjectRegistry: ProjectRegistry__factory,
@@ -157,6 +160,7 @@ export enum SQContracts {
     Treasury,
     RewardsBooster,
     StakingAllocation,
+    AllocationMananger,
 }
 
 export enum ServiceStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { AllocationMananger } from './typechain/contracts/AllocationManager.sol/AllocationMananger';
 // Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/test/SQTGiftRedeem.test.ts
+++ b/test/SQTGiftRedeem.test.ts
@@ -65,7 +65,7 @@ describe('Redeem Contract', () => {
     describe('NFT Redeem', () => {
         beforeEach(async () => {
             // create nft series 0 and mint token 0 to wallet_0
-            await nft.createSeries(100, "abc");
+            await nft.createSeries(100, 'abc');
             await nft.addToAllowlist(0, wallet_0.address, 10);
             await nft.mint(0);
         });
@@ -77,8 +77,8 @@ describe('Redeem Contract', () => {
             await sqtRedeem.deposit(amount);
             await sqtRedeem.setRedeemableAmount(nft.address, 0, amount);
             await sqtGift.approve(sqtRedeem.address, 1);
-            await expect(sqtRedeem.redeem(nft.address, 1)).to.be
-                .emit(sqtRedeem, 'SQTRedeemed')
+            await expect(sqtRedeem.redeem(nft.address, 1))
+                .to.be.emit(sqtRedeem, 'SQTRedeemed')
                 .withArgs(wallet_0.address, 1, 0, nft.address, amount);
 
             await expect(sqtRedeem.redeem(nft.address, 1)).to.revertedWith('ERC721: invalid token ID');
@@ -110,7 +110,7 @@ describe('Redeem Contract', () => {
             await sqtGift.approve(sqtRedeem.address, 2);
             await sqtGift.approve(sqtRedeem.address, 3);
             const balance = await sqToken.balanceOf(sqtRedeem.address);
-            console.log(`balance: ${balance.toString()}`)
+            console.log(`balance: ${balance.toString()}`);
 
             const tx = await sqtRedeem.batchRedeem([nft.address, nft.address, nft.address], [1, 2, 3]);
             const events = await eventsFrom(tx, sqtRedeem, 'SQTRedeemed(address,uint256,uint256,address,uint256)');

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -100,7 +100,7 @@ describe('StakingAllocation Contract', () => {
         rewardsStaking = deployment.rewardsStaking;
         rewardsDistributor = deployment.rewardsDistributor;
         stakingAllocation = deployment.stakingAllocation;
-        allocationManager = deployment.allocationMananger;
+        allocationManager = deployment.allocationManager;
         projectRegistry = deployment.projectRegistry;
 
         // config rewards booster

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -200,9 +200,7 @@ describe('StakingAllocation Contract', () => {
         });
 
         it('only RewardStaking can call applyStakeChange', async () => {
-            await expect(
-                stakingAllocation.connect(runner0).onStakeUpdate(runner0.address)
-            ).to.be.revertedWith('SAL01');
+            await expect(stakingAllocation.connect(runner0).onStakeUpdate(runner0.address)).to.be.revertedWith('SAL01');
         });
 
         it('add/del allocation', async () => {
@@ -272,16 +270,20 @@ describe('StakingAllocation Contract', () => {
                 stakingAllocation.connect(runner0).addAllocation(deploymentIds[0], runner0.address, etherParse('1000'))
             ).to.be.revertedWith('SAL06');
             await expect(
-                stakingAllocation.connect(runner0).removeAllocation(deploymentIds[0], runner0.address, etherParse('1000'))
+                stakingAllocation
+                    .connect(runner0)
+                    .removeAllocation(deploymentIds[0], runner0.address, etherParse('1000'))
             ).to.be.revertedWith('SAL06');
 
             // Caller is not `auth account`
-            await expect(allocationManager
-                .connect(runner0)
-                .addAllocation(deploymentIds[0], runner1.address, etherParse('5000'))).to.be.revertedWith('SAL02');
-            await expect(allocationManager
-                .connect(runner0)
-                .removeAllocation(deploymentIds[0], runner1.address, etherParse('5000'))).to.be.revertedWith('SAL02');
+            await expect(
+                allocationManager.connect(runner0).addAllocation(deploymentIds[0], runner1.address, etherParse('5000'))
+            ).to.be.revertedWith('SAL02');
+            await expect(
+                allocationManager
+                    .connect(runner0)
+                    .removeAllocation(deploymentIds[0], runner1.address, etherParse('5000'))
+            ).to.be.revertedWith('SAL02');
         });
     });
 });


### PR DESCRIPTION
## Changes

- Add `AllocationMananger` to resolve cycle dependency between `StakingAllocation` and `RewardBooster`
- Add `AllocationMananger` to contract deployments
- Update test, and add more test for `AllocationStaking` to check the failed casese

## TODO:
- Deploy `AllocationMananger` contract
- Upgrade `StakingAllocation` and `RewardBooster` contract