### PR TITLE
Support consumer controller for booster

### DIFF
--- a/test/RewardsBooster.test.ts
+++ b/test/RewardsBooster.test.ts
@@ -237,11 +237,11 @@ describe('RewardsBooster Contract', () => {
             const boosterAmount = etherParse('1000');
             const balanceBefore = await token.balanceOf(root.address);
             await token.increaseAllowance(rewardsBooster.address, boosterAmount);
-            await rewardsBooster.boostDeployment(deploymentId0, boosterAmount);
+            await rewardsBooster.boostDeployment(root.address, deploymentId0, boosterAmount);
             expect(await rewardsBooster.getRunnerDeploymentBooster(deploymentId0, root.address)).to.eq(boosterAmount);
             const balanceAfter = await token.balanceOf(root.address);
             expect(balanceBefore.sub(balanceAfter)).to.eq(boosterAmount);
-            await rewardsBooster.removeBoosterDeployment(deploymentId0, boosterAmount);
+            await rewardsBooster.removeBoosterDeployment(root.address, deploymentId0, boosterAmount);
             expect(await token.balanceOf(root.address)).to.eq(balanceBefore);
         });
 
@@ -249,7 +249,7 @@ describe('RewardsBooster Contract', () => {
             const perBlockReward = await rewardsBooster.issuancePerBlock();
             const boosterAmount = etherParse('10000');
             await token.increaseAllowance(rewardsBooster.address, boosterAmount);
-            await rewardsBooster.boostDeployment(deploymentId0, boosterAmount);
+            await rewardsBooster.boostDeployment(root.address, deploymentId0, boosterAmount);
             let reward = await rewardsBooster.getAccRewardsForDeployment(deploymentId0);
             expect(reward).to.eq(0);
             await blockTravel(1000);
@@ -399,7 +399,9 @@ describe('RewardsBooster Contract', () => {
                 expect(queryReward1C0).to.eq(queryReward1C1);
                 // increase consumer0's booster
                 // await blockTravel(1);
-                await rewardsBooster.connect(consumer0).removeBoosterDeployment(deploymentId3, etherParse('10000'));
+                await rewardsBooster
+                    .connect(consumer0)
+                    .removeBoosterDeployment(consumer0.address, deploymentId3, etherParse('10000'));
                 const reward1 = await rewardsBooster.getAccRewardsForDeployment(deploymentId3);
                 const queryReward2C0 = await rewardsBooster.getQueryRewards(deploymentId3, consumer0.address);
                 const queryReward2C1 = await rewardsBooster.getQueryRewards(deploymentId3, consumer1.address);

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -254,7 +254,7 @@ describe('StakingAllocation Contract', () => {
             await stakingAllocation
                 .connect(runner1)
                 .removeAllocation(deploymentIds[0], runner1.address, etherParse('500'));
-            await checkAllocation(runner1, etherParse('9000'), etherParse('9000'), false, false);
+            await checkAllocation(runner1, etherParse('9000'), etherParse('9000'), false, true);
         });
 
         it('over-allocate and recover', async () => {

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -49,7 +49,7 @@ describe('StakingAllocation Contract', () => {
 
     const boosterDeployment = async (signer: SignerWithAddress, deployment: string, amount) => {
         await token.connect(signer).increaseAllowance(rewardsBooster.address, amount);
-        await rewardsBooster.connect(signer).boostDeployment(deployment, amount);
+        await rewardsBooster.connect(signer).boostDeployment(signer.address, deployment, amount);
     };
 
     const createProject = (wallet, projectMetadata, deploymentMetadata, deploymentId, projectType: ProjectType) => {

--- a/test/fixtureLoader.ts
+++ b/test/fixtureLoader.ts
@@ -337,6 +337,7 @@ export const loaders = {
             const tx = await sdk.rewardsBooster
                 .connect(wallet)
                 .removeBoosterDeployment(
+                    wallet.address,
                     cidToBytes32(deploymentId),
                     currentBooster.sub(utils.parseEther(amount.toString()))
                 );
@@ -345,7 +346,11 @@ export const loaders = {
             console.log(`add booster ${utils.formatEther(utils.parseEther(amount.toString()).sub(currentBooster))}`);
             const tx = await sdk.rewardsBooster
                 .connect(wallet)
-                .boostDeployment(cidToBytes32(deploymentId), utils.parseEther(amount.toString()).sub(currentBooster));
+                .boostDeployment(
+                    wallet.address,
+                    cidToBytes32(deploymentId),
+                    utils.parseEther(amount.toString()).sub(currentBooster)
+                );
             await tx.wait();
         }
         console.log(`DeploymentBooster End`);

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -209,7 +209,7 @@ export async function boosterDeployment(
     amount: BigNumber
 ) {
     await token.connect(signer).increaseAllowance(rewardsBooster.address, amount);
-    await rewardsBooster.connect(signer).boostDeployment(deployment, amount);
+    await rewardsBooster.connect(signer).boostDeployment(signer.address, deployment, amount);
 }
 
 export async function openChannel(


### PR DESCRIPTION
Because the ConsumerHost contract cannot become a booster (also cannot call booster method in contract, because proxy address), does the booster need a controller to control the increase and decrease of amount?