### PR TITLE
skip collecting reward after indexer unregister

### DIFF
--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -138,6 +138,9 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable, C
             emit ICRChanged(_indexer, newCommissionRate);
             emit SettledEraUpdated(_indexer, currentEra - 1);
         } else {
+            if (!IIndexerRegistry(settings.getIndexerRegistry()).isIndexer(_indexer)) {
+                return;
+            }
             require(rewardsDistributer.collectAndDistributeEraRewards(currentEra, _indexer) == currentEra - 1, 'RS002');
             IndexerRewardInfo memory rewardInfo = rewardsDistributer.getRewardInfo(_indexer);
 


### PR DESCRIPTION
This change is made so delegators can undelegator after indexer unregister. Without the need to keep maintaining lastclaim & lastSettle by indexer

This is for kepler retirement, if ok, we need to upgrade to Kepler