### PR TITLE
Fix tokenId in SQTGift

### DIFF
--- a/contracts/SQTGift.sol
+++ b/contracts/SQTGift.sol
@@ -35,6 +35,8 @@ contract SQTGift is
     /// @notice tokenId => Gift
     mapping(uint256 => Gift) public gifts;
 
+    uint256 public nextTokenId;
+
     event AllowListAdded(address indexed account, uint256 indexed seriesId, uint8 amount);
     event AllowListRemoved(address indexed account, uint256 indexed seriesId, uint8 amount);
 
@@ -161,7 +163,8 @@ contract SQTGift is
         require(giftSerie.totalSupply < giftSerie.maxSupply, 'SQG005');
         series[_seriesId].totalSupply += 1;
 
-        uint256 tokenId = totalSupply() + 1;
+        uint256 tokenId = nextTokenId;
+        nextTokenId += 1;
         gifts[tokenId].seriesId = _seriesId;
 
         _safeMint(_account, tokenId);
@@ -193,5 +196,9 @@ contract SQTGift is
     function getSeries(uint256 tokenId) external view returns (uint256) {
         require(ownerOf(tokenId) != address(0), 'SQR006');
         return gifts[tokenId].seriesId;
+    }
+
+    function setNextTokenId(uint256 tokenId) external onlyOwner {
+        nextTokenId = tokenId;
     }
 }

--- a/publish/ABI/SQTGift.json
+++ b/publish/ABI/SQTGift.json
@@ -561,6 +561,19 @@
     },
     {
         "inputs": [],
+        "name": "nextTokenId",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "owner",
         "outputs": [
             {
@@ -738,6 +751,19 @@
             }
         ],
         "name": "setMaxSupply",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            }
+        ],
+        "name": "setNextTokenId",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/mainnet.json
+++ b/publish/mainnet.json
@@ -51,10 +51,10 @@
             "lastUpdate": "Tue, 23 Jan 2024 06:18:11 GMT"
         },
         "SQTGift": {
-            "innerAddress": "0xCa5A962a57f1A169549C250DD0FC3AE9f1C2012f",
+            "innerAddress": "0xd84e5719121211F9b8ea7c749dBb3310CCB7E02B",
             "address": "0x86DF167B61bd62320058FCc9099D82FebB9a054b",
-            "bytecodeHash": "63d232263e9fec5c38c9ae056e3ca32a383a80180b8cb4feae6c9dd93ffcdbca",
-            "lastUpdate": "Tue, 13 Feb 2024 08:00:50 GMT"
+            "bytecodeHash": "2efdc85039f451b3b7ee5fee15887be5b8fee9817e9cb056d9ea6459c0a3a918",
+            "lastUpdate": "Wed, 28 Feb 2024 03:56:57 GMT"
         },
         "Settings": {
             "innerAddress": "0xf282737992Da4217bf5f8B6AE621181e84d7d3b9",


### PR DESCRIPTION
We has been using totalSupply as tokenId, and it causes issue when people burn their token in order to redeem SQT, which reduce totalSupply and cause tokenId conflicts.
This fix introduces a new counter to generate tokenId.