### PR TITLE
Support swap booster deployment

### DIFF
--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -244,22 +244,22 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
             );
         }
 
-        DeploymentPool storage deploymentPool = deploymentPools[from];
-        require(deploymentPool.accountBooster[account] >= amount, 'RB003');
+        DeploymentPool storage fromPool = deploymentPools[from];
+        require(fromPool.accountBooster[account] >= amount, 'RB003');
 
         // remove booster from current deploymentId
         onDeploymentBoosterUpdate(from, account);
-        deploymentPool.boosterPoint -= amount;
-        deploymentPool.accountBooster[account] -= amount;
-        deploymentPool.accRewardsPerBooster = accRewardsPerBooster;
+        fromPool.boosterPoint -= amount;
+        fromPool.accountBooster[account] -= amount;
+        fromPool.accRewardsPerBooster = accRewardsPerBooster;
         emit DeploymentBoosterRemoved(from, account, amount);
 
         // add booster to the target deploymentId
-        deploymentPool = deploymentPools[to];
+        DeploymentPool storage toPool = deploymentPools[to];
         onDeploymentBoosterUpdate(to, account);
-        deploymentPool.boosterPoint += amount;
-        deploymentPool.accountBooster[account] += amount;
-        deploymentPool.accRewardsPerBooster = accRewardsPerBooster;
+        toPool.boosterPoint += amount;
+        toPool.accountBooster[account] += amount;
+        toPool.accRewardsPerBooster = accRewardsPerBooster;
         emit DeploymentBoosterAdded(to, account, amount);
     }
 

--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -15,6 +15,7 @@ import './interfaces/IEraManager.sol';
 import './interfaces/IStakingAllocation.sol';
 import './interfaces/IStakingManager.sol';
 import './interfaces/IIndexerRegistry.sol';
+import './interfaces/IConsumerRegistry.sol';
 import './interfaces/ISettings.sol';
 import './interfaces/ISQToken.sol';
 import './interfaces/IRewardsDistributor.sol';
@@ -23,7 +24,6 @@ import './interfaces/IProjectRegistry.sol';
 import './utils/FixedMath.sol';
 import './utils/MathUtil.sol';
 import './utils/StakingUtil.sol';
-import './interfaces/IConsumerRegistry.sol';
 
 /**
  * @title Rewards for running
@@ -221,7 +221,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
                 'RB014'
             );
         }
-        // address account = msg.sender;
+
         DeploymentPool storage deploymentPool = deploymentPools[from];
         require(deploymentPool.accountBooster[account] >= amount, 'RB003');
 

--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -205,12 +205,21 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
         emit DeploymentBoosterRemoved(deployment, msg.sender, amount);
     }
 
-    function swapBoosterDeployment(address account, bytes32 from, bytes32 to, uint256 amount) external {
+    function swapBoosterDeployment(
+        address account,
+        bytes32 from,
+        bytes32 to,
+        uint256 amount
+    ) external {
         require(_isDeploymentRegistered(from), 'RB008');
         require(from != to, 'RB013');
 
         if (account != msg.sender) {
-            require(IConsumerRegistry(settings.getContractAddress(SQContracts.ConsumerRegistry)).isController(account, msg.sender), 'RB014');
+            require(
+                IConsumerRegistry(settings.getContractAddress(SQContracts.ConsumerRegistry))
+                    .isController(account, msg.sender),
+                'RB014'
+            );
         }
         // address account = msg.sender;
         DeploymentPool storage deploymentPool = deploymentPools[from];
@@ -233,8 +242,9 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
     }
 
     function _isDeploymentRegistered(bytes32 deploymentId) internal view returns (bool) {
-        return IProjectRegistry(settings.getContractAddress(SQContracts.ProjectRegistry))
-            .isDeploymentRegistered(deploymentId);
+        return
+            IProjectRegistry(settings.getContractAddress(SQContracts.ProjectRegistry))
+                .isDeploymentRegistered(deploymentId);
     }
 
     function getRunnerDeploymentBooster(

--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -162,6 +162,10 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
         reporters[reporter] = allow;
     }
 
+    /**
+     * @notice
+     * @param deploymentId project deployment id
+     */
     modifier onlyRegisteredDeployment(bytes32 deploymentId) {
         require(
             IProjectRegistry(settings.getContractAddress(SQContracts.ProjectRegistry))
@@ -204,7 +208,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster {
     function removeBoosterDeployment(
         bytes32 deploymentId,
         uint256 amount
-    ) external onlyRegisteredDeployment(deploymentId) {
+    ) external {
         DeploymentPool storage deploymentPool = deploymentPools[deploymentId];
         require(deploymentPool.accountBooster[msg.sender] >= amount, 'RB003');
 

--- a/publish/ABI/RewardsBooster.json
+++ b/publish/ABI/RewardsBooster.json
@@ -1028,6 +1028,34 @@
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "from",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "to",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "swapBoosterDeployment",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "totalBoosterPoint",
         "outputs": [

--- a/publish/ABI/RewardsBooster.json
+++ b/publish/ABI/RewardsBooster.json
@@ -832,7 +832,7 @@
         "inputs": [
             {
                 "internalType": "bytes32",
-                "name": "deployment",
+                "name": "deploymentId",
                 "type": "bytes32"
             },
             {

--- a/publish/revertcode.json
+++ b/publish/revertcode.json
@@ -212,5 +212,7 @@
     "RB010": "Invalid report time when setMissedLabor",
     "RB011": "MissedLaborTime exceed current report period",
     "RB012": "Invalid param length to set MissedLabor",
+    "RB013": "Deployment ids can not be same",
+    "RB014": "Caller is not a controller of the account",
     "OPD01": "l2token address is empty"
 }

--- a/scripts/config/contracts.config.ts
+++ b/scripts/config/contracts.config.ts
@@ -4,7 +4,11 @@ export default {
     mainnet: {
         InflationController: [12000, '0x9E3a8e4d0115e5b157B61b6a5372ecc41446D472'], // inflationRate, inflationDestination
         InflationDestination: ['0xd043807A0f41EE95fD66A523a93016a53456e79B'], // XcRecipient
-        OpDestination: ['0x09395a2A58DB45db0da254c7EAa5AC469D8bDc85', '0x858c50C3AF1913b0E849aFDB74617388a1a5340d', '0x3154Cf16ccdb4C6d922629664174b904d80F2C35'],
+        OpDestination: [
+            '0x09395a2A58DB45db0da254c7EAa5AC469D8bDc85',
+            '0x858c50C3AF1913b0E849aFDB74617388a1a5340d',
+            '0x3154Cf16ccdb4C6d922629664174b904d80F2C35',
+        ],
         SQToken: [utils.parseEther('10000000000')], // initial supply 10 billion
         VTSQToken: [],
         Staking: [1209600, 1e3], // lockPeriod: 14 days, unbondFeeRate: 10e3/10e6=0.001=0.1%
@@ -17,7 +21,7 @@ export default {
         // base: 2s a block, 31536000/2 = 15768000 blocks a year, 1% rewards = 100000000 / 15768000 = about 6.3419584 SQT per block
         RewardsBooster: [utils.parseEther('6.3419584'), utils.parseEther('1000')], // _issuancePerBlock, _minimumDeploymentBooster
         L2SQToken: ['0x4200000000000000000000000000000000000010', '0x09395a2A58DB45db0da254c7EAa5AC469D8bDc85'], // l2bridge, l1token
-        PriceOracle: [10 , 3600],
+        PriceOracle: [10, 3600],
     },
     kepler: {
         InflationController: [0, '0x34c35136ECe9CBD6DfDf2F896C6e29be01587c0C'], // inflationRate, inflationDestination

--- a/scripts/config/mainnet.config.ts
+++ b/scripts/config/mainnet.config.ts
@@ -1,16 +1,16 @@
 const config = {
     multiSig: {
         root: {
-            foundation: "0x623D1426f5F45D39A1D9EbD3A5f6abeE0c8eC469",
-            teamAllocation: "0x32aB17a7d990F4afA8AD01cbFcbf49c26CFC0494",
-            foundationAllocation: "0x16F94a7719994303125bc7cEB2Dac0Cca2e9b787",
+            foundation: '0x623D1426f5F45D39A1D9EbD3A5f6abeE0c8eC469',
+            teamAllocation: '0x32aB17a7d990F4afA8AD01cbFcbf49c26CFC0494',
+            foundationAllocation: '0x16F94a7719994303125bc7cEB2Dac0Cca2e9b787',
         },
         child: {
-            foundation: "0x31E99bdA5939bA2e7528707507b017f43b67F89B",
-            treasury: "0xd043807A0f41EE95fD66A523a93016a53456e79B",
-            council: "0xDD93Add934dCc40b54f3d701C5666CFf1C9FD0Df",
-        }
-    }
-}
+            foundation: '0x31E99bdA5939bA2e7528707507b017f43b67F89B',
+            treasury: '0xd043807A0f41EE95fD66A523a93016a53456e79B',
+            council: '0xDD93Add934dCc40b54f3d701C5666CFf1C9FD0Df',
+        },
+    },
+};
 
 export default config;

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -81,7 +81,7 @@ async function getOverrides(): Promise<Overrides> {
     const price = await wallet.provider.getGasPrice();
     // console.log(`gasprice: ${price.toString()}`)
     // price = price.add(15000000000); // add extra 15 gwei
-    return { gasPrice: price, gasLimit: 3000000 };
+    return { gasPrice: price, gasLimit: 4000000 };
 }
 
 export function saveDeployment(name: string, deployment: Partial<ContractDeployment>) {

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -81,7 +81,7 @@ async function getOverrides(): Promise<Overrides> {
     const price = await wallet.provider.getGasPrice();
     // console.log(`gasprice: ${price.toString()}`)
     // price = price.add(15000000000); // add extra 15 gwei
-    return { gasPrice: price, gasLimit: 4000000 };
+    return { gasPrice: price };
 }
 
 export function saveDeployment(name: string, deployment: Partial<ContractDeployment>) {

--- a/scripts/startup.ts
+++ b/scripts/startup.ts
@@ -191,12 +191,7 @@ export async function airdrop(sdk: ContractSDK, _provider?: StaticJsonRpcProvide
 
 async function rootContractOwnerTransfer(sdk: RootContractSDK) {
     logger = getLogger('Owner Transfer');
-    const contracts = [
-        sdk.sqToken,
-        sdk.vtSQToken,
-        sdk.vesting,
-        sdk.inflationDestination,
-    ];
+    const contracts = [sdk.sqToken, sdk.vtSQToken, sdk.vesting, sdk.inflationDestination];
 
     const foundation = mainnetConfig.multiSig.root.foundation;
     logger.info(`Transfer Ownership to ${foundation}`);
@@ -214,7 +209,6 @@ async function rootContractOwnerTransfer(sdk: RootContractSDK) {
 
     // TODO: please manually transfer the ownership of `proxyAdmin` | `settings` | `infaltionController` to `mainnetConfig.multiSig.root.foundationAllocation;`
 }
-    
 
 export async function childContractOwnerTransfer(sdk: ContractSDK) {
     logger = getLogger('Owner Transfer');

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -28,9 +28,7 @@ async function checkRootInitialisation(sdk: RootContractSDK, config) {
     logger.info(`InflationRate to be equal ${rate}`);
     expect((await sdk.inflationController.inflationRate()).toNumber()).to.eq(rate);
     logger.info(`InflationDestination to be equal ${destination}`);
-    expect((await sdk.inflationController.inflationDestination()).toUpperCase()).to.equal(
-        destination.toUpperCase()
-    );
+    expect((await sdk.inflationController.inflationDestination()).toUpperCase()).to.equal(destination.toUpperCase());
     logger.info('🎉 InflationController Contract verified\n');
 
     // inflation destination
@@ -57,7 +55,7 @@ async function checkRootInitialisation(sdk: RootContractSDK, config) {
     expect(totalSupply).to.eql(amount);
     logger.info(`SQToken minter is ${sdk.inflationController.address}`);
     // TODO: update this check after TGE launched
-    expect((await sdk.sqToken.getMinter())).to.equal('0x0000000000000000000000000000000000000000');
+    expect(await sdk.sqToken.getMinter()).to.equal('0x0000000000000000000000000000000000000000');
     const wallet = mainnetConfig.multiSig.root.foundation;
     logger.info(`Foundation wallet: ${wallet} own the total assets`);
     const foundationSQTBalance = await sdk.sqToken.balanceOf(wallet);
@@ -172,7 +170,6 @@ async function checkChildInitialisation(sdk: ContractSDK, config, caller: string
         logger.info(`blockLimit to be equal ${blockLimit}`);
         expect(await sdk.priceOracle.blockLimit()).to.eql(BN(blockLimit));
         logger.info('🎉 PriceOracle Contract verified\n');
-
     } catch (err) {
         logger.info(`Failed to verify contract: ${err}`);
     }
@@ -246,7 +243,7 @@ async function checkRootContractsOwnership(sdk: RootContractSDK) {
         [sdk.inflationController, foundationW],
         // TODO: verify `settings` and `proxyAmdin` which owner is `allocationW`
     ];
-    
+
     try {
         for (const [contract, owner] of contracts) {
             // @ts-expect-error no owner interface

--- a/src/rootSdk.ts
+++ b/src/rootSdk.ts
@@ -46,12 +46,11 @@ export class RootContractSDK {
     }
 
     private async _init() {
-        const contracts = Object.entries(this._contractDeployments)
-            .map(([name, contract]) => ({
-                address: contract.address,
-                factory: CONTRACT_FACTORY[name as ContractName] as FactoryContstructor,
-                name: name as ContractName,
-            }));
+        const contracts = Object.entries(this._contractDeployments).map(([name, contract]) => ({
+            address: contract.address,
+            factory: CONTRACT_FACTORY[name as ContractName] as FactoryContstructor,
+            name: name as ContractName,
+        }));
 
         for (const { name, factory, address } of contracts) {
             if (!factory) continue;

--- a/test/RewardsBooster.test.ts
+++ b/test/RewardsBooster.test.ts
@@ -427,7 +427,6 @@ describe('RewardsBooster Contract', () => {
                 const queryReward1C0 = await rewardsBooster.getQueryRewards(deploymentId3, consumer0.address);
                 const reward0 = await rewardsBooster.getAccRewardsForDeployment(deploymentId3);
                 expect(queryReward1C0).to.eq(getQueryReward(reward0, queryRewardRatePerMill));
-
             });
         });
     });

--- a/test/RewardsBooster.test.ts
+++ b/test/RewardsBooster.test.ts
@@ -418,15 +418,24 @@ describe('RewardsBooster Contract', () => {
                 );
             });
 
-            it.skip('can swap booster from one deployment to another', async () => {
-                const queryRewardRatePerMill = await rewardsBooster.boosterQueryRewardRate(ProjectType.RPC);
-                await boosterDeployment(token, rewardsBooster, consumer0, deploymentId3, etherParse('10000'));
+            it.only('can swap booster from one deployment to another', async () => {
+                await boosterDeployment(token, rewardsBooster, consumer0, deploymentId2, etherParse('10000'));
 
-                // accumulate rewards
                 await blockTravel(999);
-                const queryReward1C0 = await rewardsBooster.getQueryRewards(deploymentId3, consumer0.address);
-                const reward0 = await rewardsBooster.getAccRewardsForDeployment(deploymentId3);
-                expect(queryReward1C0).to.eq(getQueryReward(reward0, queryRewardRatePerMill));
+                const consumer = consumer0.address;
+                await rewardsBooster.connect(consumer0).swapBoosterDeployment(consumer, deploymentId2, deploymentId3, etherParse('3000'));
+                const accRewardsPerBooster = await rewardsBooster.getAccRewardsPerBooster(); 
+                const pool1 = await rewardsBooster.deploymentPools(deploymentId2);
+                expect(pool1.boosterPoint).to.eq(etherParse('7000'));
+                expect(pool1.accRewardsPerBooster).to.eq(accRewardsPerBooster)
+                const runnerDeployment2Booster = await rewardsBooster.getRunnerDeploymentBooster(deploymentId2, consumer);
+                expect(runnerDeployment2Booster).to.eq(etherParse('7000'));
+
+                const pool2 = await rewardsBooster.deploymentPools(deploymentId1);
+                // expect(pool2.boosterPoint).to.eq(etherParse('3000'));
+                expect(pool2.accRewardsPerBooster).to.eq(accRewardsPerBooster);
+                const runnerDeployment3Booster = await rewardsBooster.getRunnerDeploymentBooster(deploymentId3, consumer);
+                // expect(runnerDeployment3Booster).to.eq(etherParse('3000'));
             });
         });
     });

--- a/test/RewardsBooster.test.ts
+++ b/test/RewardsBooster.test.ts
@@ -417,6 +417,18 @@ describe('RewardsBooster Contract', () => {
                     getQueryReward(reward2.sub(reward1), queryRewardRatePerMill)
                 );
             });
+
+            it.skip('can swap booster from one deployment to another', async () => {
+                const queryRewardRatePerMill = await rewardsBooster.boosterQueryRewardRate(ProjectType.RPC);
+                await boosterDeployment(token, rewardsBooster, consumer0, deploymentId3, etherParse('10000'));
+
+                // accumulate rewards
+                await blockTravel(999);
+                const queryReward1C0 = await rewardsBooster.getQueryRewards(deploymentId3, consumer0.address);
+                const reward0 = await rewardsBooster.getAccRewardsForDeployment(deploymentId3);
+                expect(queryReward1C0).to.eq(getQueryReward(reward0, queryRewardRatePerMill));
+
+            });
         });
     });
 

--- a/test/fixtures/rpc_projects.yaml
+++ b/test/fixtures/rpc_projects.yaml
@@ -45,104 +45,104 @@
 - kind: Project
   projectType: 1 # rpc
   metadata:
-    name: Eth Mainnet Rpc - Full Node
-    description: ''
-    websiteUrl: https://ethereum.org/
+      name: Eth Mainnet Rpc - Full Node
+      description: ''
+      websiteUrl: https://ethereum.org/
   deployments:
-    - deployment: |
-        kind: ChainRpc
-        specVersion: 1.0.0
-        name: eth-mainnet - full
-        chain:
-          chainId: 1
-        rpcFamily:
-          - evm
-        nodeType: full
-        rpcDenyList:
-          - admin
-          - debug
-          - txpool
-          - personal
-          - miner
-          - les
-      version:
-        version: 1.0.0
-        description: ''
+      - deployment: |
+            kind: ChainRpc
+            specVersion: 1.0.0
+            name: eth-mainnet - full
+            chain:
+              chainId: 1
+            rpcFamily:
+              - evm
+            nodeType: full
+            rpcDenyList:
+              - admin
+              - debug
+              - txpool
+              - personal
+              - miner
+              - les
+        version:
+            version: 1.0.0
+            description: ''
 - kind: Project
   projectType: 1 # rpc
   metadata:
-    name: Eth Mainnet Rpc - Archive Node
-    description: ''
-    websiteUrl: https://ethereum.org/
+      name: Eth Mainnet Rpc - Archive Node
+      description: ''
+      websiteUrl: https://ethereum.org/
   deployments:
-    - deployment: |
-        kind: ChainRpc
-        specVersion: 1.0.0
-        name: eth-mainnet - archive
-        chain:
-          chainId: 1
-        rpcFamily:
-          - evm
-        nodeType: archive
-        rpcDenyList:
-          - admin
-          - debug
-          - txpool
-          - personal
-          - miner
-          - les
-      version:
-        version: 1.0.0
-        description: ''
+      - deployment: |
+            kind: ChainRpc
+            specVersion: 1.0.0
+            name: eth-mainnet - archive
+            chain:
+              chainId: 1
+            rpcFamily:
+              - evm
+            nodeType: archive
+            rpcDenyList:
+              - admin
+              - debug
+              - txpool
+              - personal
+              - miner
+              - les
+        version:
+            version: 1.0.0
+            description: ''
 - kind: Project
   projectType: 1 # rpc
   metadata:
-    name: Base Rpc - Full Node
-    description: ''
-    websiteUrl: https://base.org/
+      name: Base Rpc - Full Node
+      description: ''
+      websiteUrl: https://base.org/
   deployments:
-    - deployment: |
-        kind: ChainRpc
-        specVersion: 1.0.0
-        name: base - full
-        chain:
-          chainId: 8453
-        rpcFamily:
-          - evm
-        nodeType: full
-        rpcDenyList:
-          - admin
-          - debug
-          - txpool
-          - personal
-          - miner
-          - les
-      version:
-        version: 1.0.0
-        description: ''
+      - deployment: |
+            kind: ChainRpc
+            specVersion: 1.0.0
+            name: base - full
+            chain:
+              chainId: 8453
+            rpcFamily:
+              - evm
+            nodeType: full
+            rpcDenyList:
+              - admin
+              - debug
+              - txpool
+              - personal
+              - miner
+              - les
+        version:
+            version: 1.0.0
+            description: ''
 - kind: Project
   projectType: 1 # rpc
   metadata:
-    name: Base Rpc - Archive Node
-    description: ''
-    websiteUrl: https://base.org/
+      name: Base Rpc - Archive Node
+      description: ''
+      websiteUrl: https://base.org/
   deployments:
-    - deployment: |
-        kind: ChainRpc
-        specVersion: 1.0.0
-        name: base - archive
-        chain:
-          chainId: 8453
-        rpcFamily:
-          - evm
-        nodeType: archive
-        rpcDenyList:
-          - admin
-          - debug
-          - txpool
-          - personal
-          - miner
-          - les
-      version:
-        version: 1.0.0
-        description: ''
+      - deployment: |
+            kind: ChainRpc
+            specVersion: 1.0.0
+            name: base - archive
+            chain:
+              chainId: 8453
+            rpcFamily:
+              - evm
+            nodeType: archive
+            rpcDenyList:
+              - admin
+              - debug
+              - txpool
+              - personal
+              - miner
+              - les
+        version:
+            version: 1.0.0
+            description: ''

--- a/test/fixtures/settings.yaml
+++ b/test/fixtures/settings.yaml
@@ -7,11 +7,11 @@
   issuancePerBlock: '6341958400000000000' # 6.34
 - kind: ProjectTypeCreatorRestricted
   value:
-    - projectType: 0 # subquery project
-      restricted: true
-    - projectType: 1 # rpc
-      restricted: true
-    - projectType: 2 # dict
-      restricted: true
-    - projectType: 3 # subgraqh
-      restricted: true
+      - projectType: 0 # subquery project
+        restricted: true
+      - projectType: 1 # rpc
+        restricted: true
+      - projectType: 2 # dict
+        restricted: true
+      - projectType: 3 # subgraqh
+        restricted: true


### PR DESCRIPTION
## Changes

- Add `swapBoosterDeployment` in RewardsBooster contract to support consumer or controller account can swap booster from one deployment to another
- Update test