### PR TITLE
make node operator stake weighted

### DIFF
--- a/contracts/RewardsDistributor.sol
+++ b/contracts/RewardsDistributor.sol
@@ -332,7 +332,7 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
         );
         rewardsStaking.checkAndReflectSettlement(runner, rewardInfo.lastClaimEra);
         require(rewardInfo.lastClaimEra <= rewardsStaking.getLastSettledEra(runner), 'RD005');
-
+        rewardsStaking.applyRunnerWeightChange(runner);
         rewardInfo.lastClaimEra++;
 
         // claim rewards pool.

--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -301,7 +301,7 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
         ).getCommissionRate(runner);
         commissionRates[runner] = newCommissionRate;
         pendingCommissionRateChange[runner] = 0;
-        _updateTotalStakingAmount(stakingManager, runner, rewardInfo.lastClaimEra);
+        _updateTotalStakingAmount(stakingManager, runner, rewardInfo.lastClaimEra, true);
         emit ICRChanged(runner, newCommissionRate);
     }
 

--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -449,8 +449,8 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
     }
 
     function runnerStakeWeight() public view returns (uint256) {
-        if (_runnerStakeWeight < 1e6) {
-            return 1e6;
+        if (_runnerStakeWeight < PER_MILL) {
+            return PER_MILL;
         } else {
             return _runnerStakeWeight;
         }
@@ -458,8 +458,8 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
 
     function previousRunnerStakeWeight(address runner) public view returns (uint256) {
         uint256 runnerStakeWeight = _previousRunnerStakeWeights[runner];
-        if (runnerStakeWeight < 1e6) {
-            return 1e6;
+        if (runnerStakeWeight < PER_MILL) {
+            return PER_MILL;
         } else {
             return runnerStakeWeight;
         }

--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -346,8 +346,8 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
             // can not find unaltered ownstake, revert calculate from currentStake
             uint256 newStake = MathUtil.mulDiv(
                 currentStake,
-                _previousRunnerStakeWeight,
-                _runnerStakeWeight
+                _runnerStakeWeight,
+                _previousRunnerStakeWeight
             );
             //            assert(newStake >= currentStake, 'error todo');
             uint256 newDebtAmount = MathUtil.mulDiv(newStake, rewardInfo.accSQTPerStake, PER_TRILL);

--- a/contracts/RewardsStaking.sol
+++ b/contracts/RewardsStaking.sol
@@ -149,8 +149,8 @@ contract RewardsStaking is IRewardsStaking, Initializable, OwnableUpgradeable {
             // apply _runnerStakeWeight
             uint256 _runnerStakeWeight = runnerStakeWeight();
             newDelegation = MathUtil.mulDiv(newDelegation, _runnerStakeWeight, PER_MILL);
-            if (_previousRunnerStakeWeights[runner] != _runnerStakeWeight) {
-                _previousRunnerStakeWeights[runner] = _runnerStakeWeight;
+            if (_previousRunnerStakeWeights[_runner] != _runnerStakeWeight) {
+                _previousRunnerStakeWeights[_runner] = _runnerStakeWeight;
             }
             // end
             delegation[_runner][_runner] = newDelegation;

--- a/contracts/interfaces/IRewardsStaking.sol
+++ b/contracts/interfaces/IRewardsStaking.sol
@@ -22,4 +22,6 @@ interface IRewardsStaking {
     function getLastSettledEra(address indexer) external view returns (uint256);
 
     function getDelegationAmount(address source, address indexer) external view returns (uint256);
+
+    function applyRunnerWeightChange(address _runner) external;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@subql/contract-sdk",
-    "version": "1.1.0",
+    "version": "1.1.1-0",
     "main": "index.js",
     "license": "GPL3",
     "scripts": {

--- a/publish/ABI/RewardsStaking.json
+++ b/publish/ABI/RewardsStaking.json
@@ -111,6 +111,19 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "_runner",
+                "type": "address"
+            }
+        ],
+        "name": "applyRunnerWeightChange",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "runner",
                 "type": "address"
             },
@@ -355,8 +368,53 @@
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "runner",
+                "type": "address"
+            }
+        ],
+        "name": "previousRunnerStakeWeight",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "runnerStakeWeight",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_weight",
+                "type": "uint256"
+            }
+        ],
+        "name": "setRunnerStakeWeight",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/ABI/RewardsStaking.json
+++ b/publish/ABI/RewardsStaking.json
@@ -54,6 +54,44 @@
         "anonymous": false,
         "inputs": [
             {
+                "indexed": false,
+                "internalType": "string",
+                "name": "param",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "ParameterUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "runner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "weight",
+                "type": "uint256"
+            }
+        ],
+        "name": "RunnerWeightApplied",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
                 "indexed": true,
                 "internalType": "address",
                 "name": "runner",

--- a/publish/testnet.json
+++ b/publish/testnet.json
@@ -141,10 +141,10 @@
             "lastUpdate": "Fri, 09 Feb 2024 05:52:10 GMT"
         },
         "RewardsStaking": {
-            "innerAddress": "0x5d8edA19e7ff2f643A9824f1C51428B274935FcB",
+            "innerAddress": "0x04Cd739fE7E1a684f3c97F1EE09894c66F51a104",
             "address": "0xB64D73B96358855075576D66746D2a88e043CC1E",
-            "bytecodeHash": "3860357946ad2b98483b64d3c3336fda91ecf0bd14d2d13e5b4f70b86da85afc",
-            "lastUpdate": "Wed, 01 May 2024 04:37:20 GMT"
+            "bytecodeHash": "973d6f56de547f460b966b06a0189163146471417c3d8d25e47217315fd78b26",
+            "lastUpdate": "Mon, 06 May 2024 21:47:28 GMT"
         },
         "RewardsHelper": {
             "innerAddress": "0xa7eE3bFD854bd609D1485FE845d996EEDE87aF7B",

--- a/publish/testnet.json
+++ b/publish/testnet.json
@@ -141,10 +141,10 @@
             "lastUpdate": "Fri, 09 Feb 2024 05:52:10 GMT"
         },
         "RewardsStaking": {
-            "innerAddress": "0x76105B682f20977FD4B178271739B0737F6dC33c",
+            "innerAddress": "0x5d8edA19e7ff2f643A9824f1C51428B274935FcB",
             "address": "0xB64D73B96358855075576D66746D2a88e043CC1E",
-            "bytecodeHash": "ba0b25deebb4f77bf140d5d3d6987a3df7b943c4f30afd9ad2654845dc1e119b",
-            "lastUpdate": "Thu, 28 Mar 2024 07:11:47 GMT"
+            "bytecodeHash": "3860357946ad2b98483b64d3c3336fda91ecf0bd14d2d13e5b4f70b86da85afc",
+            "lastUpdate": "Wed, 01 May 2024 04:37:20 GMT"
         },
         "RewardsHelper": {
             "innerAddress": "0xa7eE3bFD854bd609D1485FE845d996EEDE87aF7B",

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -219,7 +219,7 @@ describe('RewardsDistributor Contract', () => {
         });
     });
 
-    describe.only('Rewards Split Amongst Operator & Delegators', () => {
+    describe('Rewards Split Amongst Operator & Delegators', () => {
         // runner stake: 1000
         // delegation: 9000
         const runnerStake = etherParse(1000);

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -635,7 +635,7 @@ describe('RewardsDistributor Contract', () => {
             await checkValues(etherParse('4.996702697'), etherParse('9.001697302697'), etherParse('1002'), 0);
         });
 
-        it.only('reward distribution should work after indexer reregister few more ears later', async () => {
+        it('reward distribution should work after indexer reregister few more ears later', async () => {
             // 1. delegator undelegate all the tokens
             await stakingManager.connect(delegator).undelegate(runner.address, etherParse('1'));
             // 2. start new era -> indexer `collectAndDistributeRewards` -> `applyStakeChange | delegator -> `applyStakeChange`

--- a/test/fixtureLoader.ts
+++ b/test/fixtureLoader.ts
@@ -39,6 +39,7 @@ export interface IndexerControllerInput {
 }
 
 export interface ProjectInput {
+    id: string;
     account: string;
     metadata: object;
     projectType: number;
@@ -150,7 +151,7 @@ export const loaders = {
         }
     },
     Project: async function (
-        { account, deployments, metadata, projectType }: ProjectInput,
+        { account, deployments, metadata, projectType, id }: ProjectInput,
         { accounts, ipfs, sdk, rootAccount }: Context
     ) {
         console.log(`Project Start for ${metadata['name']}`);
@@ -163,6 +164,12 @@ export const loaders = {
         if (!deploymentId) {
             const { cid: deploymentCid } = await ipfs.add(firstDeploy.deployment, { pin: true });
             deploymentId = deploymentCid.toString();
+        }
+        // update metadata
+        if (id) {
+            const tx = await sdk.projectRegistry.connect(author).updateProjectMetadata(id, metadataCid.toString());
+            await tx.wait();
+            return;
         }
         const tx = await sdk.projectRegistry
             .connect(author)

--- a/test/fixtureLoader.ts
+++ b/test/fixtureLoader.ts
@@ -191,14 +191,16 @@ export const loaders = {
         assert(indexer, `can't find indexer account ${account}`);
         let tx;
         if (action === 'index') {
-            tx = await sdk.projectRegistry.connect(indexer).startService(cidToBytes32(deploymentId), indexer.address);
+            tx = await sdk.projectRegistry.connect(indexer).startService2(cidToBytes32(deploymentId), indexer.address);
         } else if (action === 'ready') {
             const status = await sdk.projectRegistry.deploymentStatusByIndexer(
                 cidToBytes32(deploymentId),
                 indexer.address
             );
             if (status === 1) {
-                tx = await sdk.projectRegistry.connect(indexer).startService(cidToBytes32(deploymentId), indexer.address);
+                tx = await sdk.projectRegistry
+                    .connect(indexer)
+                    .startService2(cidToBytes32(deploymentId), indexer.address);
             } else {
                 console.log(`skip because the current status is ${status}`);
             }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -281,7 +281,8 @@ export async function acceptPlan(
         sqtToken.address,
         METADATA_HASH
     );
-    await planManager.connect(indexer).createPlan(value, 0, DEPLOYMENT_ID);
+    const planTplId = (await planManager.nextTemplateId()).toNumber() - 1;
+    await planManager.connect(indexer).createPlan(value, planTplId, DEPLOYMENT_ID);
     await planManager.connect(consumer).acceptPlan((await planManager.nextPlanId()).toNumber() - 1, DEPLOYMENT_ID);
 }
 


### PR DESCRIPTION
Allow node operators stake to have higher weight than delegators

new storage
* _runnerStakeWeight: the global node operator's stake weight, it must > 1e6 otherwise will be ignored.
* _previousRunnerStakeWeights: record the previous node operator's stake weight so even though node operator doesn't change their stake, in collectAndDistributeEraRewards() we will still apply the _runnerStakeWeight for him

Changes
* when apply stake changes for node operator, use _runnerStakeWeight to calculate weight
* when collectAndDistributeEraRewards, apply _runnerStakeWeight if it wasn't applied or changed.
* _updateTotalStakingAmount() will also patch with _runnerStakeWeight, so totalStakingAmount won't be overwritten by delegation changes.

TODO:
* <del>add more tests</del>