### PR TITLE
Vesting on L2

### DIFF
--- a/contracts/l2/L2Vesting.sol
+++ b/contracts/l2/L2Vesting.sol
@@ -26,8 +26,6 @@ contract L2Vesting is Initializable, OwnableUpgradeable {
 
     ISettings public settings;
 
-    //    /// @notice token for vesting
-    //    address public token;
     /// @notice vesting plans
     VestingPlan[] public plans;
 
@@ -86,11 +84,9 @@ contract L2Vesting is Initializable, OwnableUpgradeable {
 
     function _allocateVesting(address addr, uint256 planId, uint256 allocation) internal {
         require(addr != address(0x0), 'V002');
-        //        require(allocations[planId][addr] == 0, 'V003');
         require(allocation > 0, 'V004');
         require(planId < plans.length, 'V013');
 
-        //        userPlanId[addr] = planId;
         allocations[planId][addr] += allocation;
 
         emit VestingAllocated(addr, planId, allocation);
@@ -120,12 +116,7 @@ contract L2Vesting is Initializable, OwnableUpgradeable {
     }
 
     function startVesting(uint256 _planId, uint256 _vestingStartDate) external onlyOwner {
-        //        require(block.timestamp < _vestingStartDate, 'V009');
         plans[_planId].startDate = _vestingStartDate;
-        //        vestingStartDate = _vestingStartDate;
-        //
-        //        uint256 amount = IERC20(token).balanceOf(address(this));
-        //        require(amount == totalAllocation, 'V010');
     }
 
     function claim(uint256 planId) external {

--- a/contracts/l2/L2Vesting.sol
+++ b/contracts/l2/L2Vesting.sol
@@ -1,0 +1,197 @@
+// Copyright (C) 2020-2024 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.15;
+
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts/utils/Address.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '../interfaces/ISQToken.sol';
+import '../interfaces/ISettings.sol';
+
+contract L2Vesting is Initializable, OwnableUpgradeable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Vesting plan
+    struct VestingPlan {
+        uint256 lockPeriod;
+        uint256 vestingPeriod;
+        uint256 initialUnlockPercent;
+        uint256 startDate;
+        uint256 totalAllocation;
+        uint256 totalClaimed;
+    }
+
+    ISettings public settings;
+
+    //    /// @notice token for vesting
+    //    address public token;
+    /// @notice vesting plans
+    VestingPlan[] public plans;
+
+    /// @notice allovation ammout for user by planId: planId => user => amount
+    mapping(uint256 => mapping(address => uint256)) public allocations;
+    /// @notice claimed amount for user by planId: planId => user => amount
+    mapping(uint256 => mapping(address => uint256)) public claimed;
+
+    /**
+     * @dev Emitted when a new vesting plan is added
+     */
+    event VestingPlanAdded(
+        uint256 planId,
+        uint256 lockPeriod,
+        uint256 vestingPeriod,
+        uint256 initialUnlockPercent
+    );
+    /**
+     * @dev Emitted when a new vesting allocation is added to a user by planId
+     */
+    event VestingAllocated(address indexed user, uint256 planId, uint256 allocation);
+    /**
+     * @dev Emitted when a user claims vested tokens
+     */
+    event VestingClaimed(address indexed user, uint256 planId, uint256 amount);
+
+    /**
+     * @dev Initialize this contract.
+     */
+    function initialize(ISettings _settings) external initializer {
+        __Ownable_init();
+
+        // Settings
+        settings = _settings;
+    }
+
+    /**
+     * @notice Update setting state.
+     * @param _settings ISettings contract
+     */
+    function setSettings(ISettings _settings) external onlyOwner {
+        settings = _settings;
+    }
+
+    function addVestingPlan(
+        uint256 _lockPeriod,
+        uint256 _vestingPeriod,
+        uint256 _initialUnlockPercent
+    ) public onlyOwner {
+        require(_initialUnlockPercent <= 100, 'V001');
+        plans.push(VestingPlan(_lockPeriod, _vestingPeriod, _initialUnlockPercent, 0, 0, 0));
+
+        // emit event for vesting plan addition
+        emit VestingPlanAdded(plans.length - 1, _lockPeriod, _vestingPeriod, _initialUnlockPercent);
+    }
+
+    function _allocateVesting(address addr, uint256 planId, uint256 allocation) internal {
+        require(addr != address(0x0), 'V002');
+        //        require(allocations[planId][addr] == 0, 'V003');
+        require(allocation > 0, 'V004');
+        require(planId < plans.length, 'V013');
+
+        //        userPlanId[addr] = planId;
+        allocations[planId][addr] += allocation;
+
+        emit VestingAllocated(addr, planId, allocation);
+    }
+
+    function batchAllocateVesting(
+        uint256[] calldata _planIds,
+        address[] calldata _addrs,
+        uint256[] calldata _allocations
+    ) external onlyOwner {
+        require(_addrs.length > 0, 'V005');
+        require(_addrs.length == _allocations.length, 'V006');
+        require(_addrs.length == _planIds.length, 'V006');
+
+        for (uint256 i = 0; i < _addrs.length; i++) {
+            _allocateVesting(_addrs[i], _planIds[i], _allocations[i]);
+
+            unchecked {
+                plans[_planIds[i]].totalAllocation += _allocations[i];
+            }
+        }
+    }
+
+    function withdrawAllByAdmin() external onlyOwner {
+        uint256 amount = _token().balanceOf(address(this));
+        require(_token().transfer(msg.sender, amount), 'V008');
+    }
+
+    function startVesting(uint256 _planId, uint256 _vestingStartDate) external onlyOwner {
+        //        require(block.timestamp < _vestingStartDate, 'V009');
+        plans[_planId].startDate = _vestingStartDate;
+        //        vestingStartDate = _vestingStartDate;
+        //
+        //        uint256 amount = IERC20(token).balanceOf(address(this));
+        //        require(amount == totalAllocation, 'V010');
+    }
+
+    function claim(uint256 planId) external {
+        _claim(planId, msg.sender);
+    }
+
+    function claimFor(uint256 planId, address account) external {
+        _claim(planId, account);
+    }
+
+    function _claim(uint256 planId, address account) internal {
+        require(planId < plans.length, 'V013');
+        require(allocations[planId][account] != 0, 'V011');
+
+        uint256 amount = claimableAmount(planId, account);
+        require(amount > 0, 'V012');
+
+        claimed[planId][account] += amount;
+        plans[planId].totalClaimed += amount;
+
+        require(claimed[planId][account] <= allocations[planId][account], 'V012');
+
+        require(_token().transfer(account, amount), 'V008');
+        emit VestingClaimed(account, planId, amount);
+    }
+
+    function claimableAmount(uint256 planId, address user) public view returns (uint256) {
+        return unlockedAmount(planId, user);
+    }
+
+    function unlockedAmount(uint256 planId, address user) public view returns (uint256) {
+        VestingPlan memory plan = plans[planId];
+        // vesting start date is not set or allocation is empty
+        uint256 vestingStartDate = plan.startDate;
+        if (vestingStartDate == 0 || allocations[planId][user] == 0) {
+            return 0;
+        }
+
+        uint256 planStartDate = vestingStartDate + plan.lockPeriod;
+
+        if (block.timestamp <= planStartDate) {
+            return 0;
+        }
+
+        // no versting period or vesting period passed
+        uint256 planCompleteDate = planStartDate + plan.vestingPeriod;
+        if (plan.vestingPeriod == 0 || block.timestamp > planCompleteDate) {
+            return allocations[planId][user] - claimed[planId][user];
+        }
+
+        // druring plan period
+        uint256 vestedPeriod = block.timestamp - planStartDate;
+        uint256 initialAmount = (allocations[planId][user] * plan.initialUnlockPercent) / 100;
+        uint256 vestingTokens = allocations[planId][user] - initialAmount;
+        return
+            initialAmount +
+            (vestingTokens * vestedPeriod) /
+            plan.vestingPeriod -
+            claimed[planId][user];
+    }
+
+    function plansLength() external view returns (uint256) {
+        return plans.length;
+    }
+
+    function _token() internal returns (IERC20) {
+        return IERC20(settings.getContractAddress(SQContracts.SQToken));
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -389,6 +389,15 @@ task('publishChild', 'verify and publish contracts on etherscan')
                 address: deployment.StakingAllocation.innerAddress,
                 constructorArguments: [],
             });
+            //L2Vesting
+            await hre.run('verify:verify', {
+                address: deployment.L2Vesting.address,
+                constructorArguments: [deployment.L2Vesting.innerAddress, deployment.ProxyAdmin.address, []],
+            });
+            await hre.run('verify:verify', {
+                address: deployment.L2Vesting.innerAddress,
+                constructorArguments: [],
+            });
         } catch (err) {
             console.log(err);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@subql/contract-sdk",
-    "version": "1.0.3",
+    "version": "1.0.4-0",
     "main": "index.js",
     "license": "GPL3",
     "scripts": {

--- a/publish/testnet.json
+++ b/publish/testnet.json
@@ -211,6 +211,12 @@
             "address": "0x748Fb3A2DBCC300b2a382820Ebec46B77718EF22",
             "bytecodeHash": "122b9796060b8325d5f2fc93d3d6ffe3f362cb676fcae9c225f15f8796de0d56",
             "lastUpdate": "Thu, 22 Feb 2024 13:34:02 GMT"
+        },
+        "L2Vesting": {
+            "innerAddress": "0x56Df28931E4216e7E84Da3A86779A59f0F2Faf4E",
+            "address": "0x7635F80079d6054995Dcd311d673c9f72be364e1",
+            "bytecodeHash": "23cc852f0716e414d6aeaee3a36813ca9a07df9715827cf9682f48aad9544ec6",
+            "lastUpdate": "Mon, 15 Apr 2024 04:36:55 GMT"
         }
     }
 }

--- a/scripts/contracts.ts
+++ b/scripts/contracts.ts
@@ -2,7 +2,6 @@ import CONTRACTS from '../src/contracts';
 
 import {
     Airdropper,
-    Airdropper__factory,
     ConsumerHost,
     ConsumerHost__factory,
     ConsumerRegistry,
@@ -19,7 +18,6 @@ import {
     PermissionedExchange,
     PermissionedExchange__factory,
     TokenExchange,
-    TokenExchange__factory,
     PlanManager,
     PlanManager__factory,
     PriceOracle,
@@ -27,7 +25,6 @@ import {
     ProjectRegistry,
     ProjectRegistry__factory,
     ProxyAdmin,
-    ProxyAdmin__factory,
     PurchaseOfferMarket,
     PurchaseOfferMarket__factory,
     RewardsDistributor,
@@ -42,7 +39,6 @@ import {
     RewardsBooster__factory,
     ERC20,
     SQToken,
-    SQToken__factory,
     ServiceAgreementRegistry,
     ServiceAgreementRegistry__factory,
     Settings,
@@ -56,21 +52,18 @@ import {
     StateChannel,
     StateChannel__factory,
     VSQToken,
-    VSQToken__factory,
     Vesting,
-    Vesting__factory,
     OpDestination,
-    OpDestination__factory,
     SQTGift__factory,
     SQTGift,
     SQTRedeem__factory,
     SQTRedeem,
     VTSQToken,
-    VTSQToken__factory,
-    L2SQToken__factory,
     FactoryContstructor,
     AirdropperLite__factory,
     AirdropperLite,
+    L2Vesting,
+    L2Vesting__factory,
 } from '../src';
 
 export type Contracts = {
@@ -108,6 +101,7 @@ export type Contracts = {
     sqtGift: SQTGift;
     sqtRedeem: SQTRedeem;
     airdropperLite: AirdropperLite;
+    l2Vesting: L2Vesting;
 };
 
 export const UPGRADEBAL_CONTRACTS: Partial<
@@ -138,43 +132,7 @@ export const UPGRADEBAL_CONTRACTS: Partial<
     SQTGift: [CONTRACTS.SQTGift, SQTGift__factory],
     AirdropperLite: [CONTRACTS.AirdropperLite, AirdropperLite__factory],
     SQTRedeem: [CONTRACTS.SQTRedeem, SQTRedeem__factory],
-};
-
-export const CONTRACT_FACTORY: Record<ContractName, FactoryContstructor> = {
-    ProxyAdmin: ProxyAdmin__factory,
-    Settings: Settings__factory,
-    InflationController: InflationController__factory,
-    SQToken: SQToken__factory,
-    VSQToken: VSQToken__factory,
-    Airdropper: Airdropper__factory,
-    Vesting: Vesting__factory,
-    VTSQToken: VTSQToken__factory,
-    Staking: Staking__factory,
-    StakingManager: StakingManager__factory,
-    StakingAllocation: StakingAllocation__factory,
-    EraManager: EraManager__factory,
-    IndexerRegistry: IndexerRegistry__factory,
-    ProjectRegistry: ProjectRegistry__factory,
-    PlanManager: PlanManager__factory,
-    PurchaseOfferMarket: PurchaseOfferMarket__factory,
-    ServiceAgreementRegistry: ServiceAgreementRegistry__factory,
-    RewardsDistributor: RewardsDistributor__factory,
-    RewardsPool: RewardsPool__factory,
-    RewardsStaking: RewardsStaking__factory,
-    RewardsHelper: RewardsHelper__factory,
-    RewardsBooster: RewardsBooster__factory,
-    StateChannel: StateChannel__factory,
-    PermissionedExchange: PermissionedExchange__factory,
-    TokenExchange: TokenExchange__factory,
-    ConsumerHost: ConsumerHost__factory,
-    DisputeManager: DisputeManager__factory,
-    ConsumerRegistry: ConsumerRegistry__factory,
-    PriceOracle: PriceOracle__factory,
-    OpDestination: OpDestination__factory,
-    SQTGift: SQTGift__factory,
-    SQTRedeem: SQTRedeem__factory,
-    L2SQToken: L2SQToken__factory,
-    AirdropperLite: AirdropperLite__factory,
+    L2Vesting: [CONTRACTS.L2Vesting, L2Vesting__factory],
 };
 
 export type Config = number | string | string[];

--- a/scripts/deployContracts.ts
+++ b/scripts/deployContracts.ts
@@ -10,6 +10,7 @@ import sha256 from 'sha256';
 
 import CONTRACTS from '../src/contracts';
 import {
+    CONTRACT_FACTORY,
     ContractDeployment,
     ContractDeploymentInner,
     ContractName,
@@ -55,8 +56,9 @@ import {
     StakingAllocation,
     L2SQToken,
     AirdropperLite,
+    L2Vesting,
 } from '../src';
-import { CONTRACT_FACTORY, Config, ContractConfig, Contracts, UPGRADEBAL_CONTRACTS } from './contracts';
+import { Config, ContractConfig, Contracts, UPGRADEBAL_CONTRACTS } from './contracts';
 import { l1StandardBridge } from './L1StandardBridge';
 
 let wallet: Wallet;
@@ -515,6 +517,13 @@ export async function deployContracts(
             initConfig: [settingsAddress],
         });
 
+        //deploy vesting contract
+        const l2Vesting = await deployContract<L2Vesting>('L2Vesting', 'child', {
+            proxyAdmin,
+            initConfig: [settingsAddress],
+        });
+        logger?.info('🤞 L2Vesting');
+
         // Register addresses on settings contract
         logger?.info('🤞 Set settings addresses');
         const txToken = await settings.setBatchAddress(
@@ -594,6 +603,7 @@ export async function deployContracts(
                 sqtRedeem,
                 airdropper,
                 stakingAllocation,
+                l2Vesting,
             },
         ];
     } catch (error) {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -35,6 +35,7 @@ import SQTGift from './artifacts/contracts/SQTGift.sol/SQTGift.json';
 import SQTRedeem from './artifacts/contracts/SQTRedeem.sol/SQTRedeem.json';
 import L2SQToken from './artifacts/contracts/l2/L2SQToken.sol/L2SQToken.json';
 import AirdropperLite from './artifacts/contracts/root/AirdropperLite.sol/AirdropperLite.json';
+import L2Vesting from './artifacts/contracts/l2/L2Vesting.sol/L2Vesting.json';
 
 export default {
     Settings,
@@ -71,4 +72,5 @@ export default {
     SQTRedeem,
     L2SQToken,
     AirdropperLite,
+    L2Vesting,
 };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -31,6 +31,7 @@ import {
     ERC20,
     RewardsBooster,
     StakingAllocation,
+    L2Vesting,
 } from './typechain';
 import { CONTRACT_FACTORY, ContractDeploymentInner, ContractName, FactoryContstructor, SdkOptions } from './types';
 import assert from 'assert';
@@ -71,6 +72,7 @@ export class ContractSDK {
     readonly sqtGift!: SQTGift;
     readonly sqtRedeem!: SQTRedeem;
     readonly stakingAllocation!: StakingAllocation;
+    readonly l2Vesting!: L2Vesting;
 
     constructor(
         // eslint-disable-next-line no-unused-vars

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ import {
     StakingAllocation__factory,
     L2SQToken__factory,
     AirdropperLite__factory,
+    L2Vesting__factory,
 } from './typechain';
 
 export type SubqueryNetwork = 'testnet' | 'testnet-mumbai' | 'mainnet' | 'local';
@@ -135,6 +136,7 @@ export const CONTRACT_FACTORY: Record<ContractName, FactoryContstructor> = {
     SQTRedeem: SQTRedeem__factory,
     L2SQToken: L2SQToken__factory,
     AirdropperLite: AirdropperLite__factory,
+    L2Vesting: L2Vesting__factory,
 };
 
 export enum SQContracts {

--- a/test/VestingL2.test.ts
+++ b/test/VestingL2.test.ts
@@ -5,10 +5,9 @@ import { Wallet } from '@ethersproject/wallet';
 import { expect } from 'chai';
 import { BigNumber, utils } from 'ethers';
 import { ethers, waffle } from 'hardhat';
-import { SQToken, Vesting, VTSQToken } from '../src';
-import { etherParse, eventFrom, lastestBlockTime, revertMsg, timeTravel, timeTravelTo } from './helper';
-import { deployRootContracts } from './setup';
-import { EXPECTATION, PLANS } from './Vesting.test-data';
+import { ERC20, L2Vesting } from '../src';
+import { eventFrom, revertMsg, timeTravel, timeTravelTo } from './helper';
+import { deployContracts } from './setup';
 import * as console from 'console';
 
 type ClaimVestingEvent = { user: string; amount: BigNumber };
@@ -17,9 +16,8 @@ describe('Vesting Contract', () => {
     const mockProvider = waffle.provider;
     const [wallet, wallet1, wallet2, wallet3, wallet4, b0, b1, b2, b3, b4, b5] = mockProvider.getWallets();
 
-    let sqToken: SQToken;
-    let vtSQToken: VTSQToken;
-    let vestingContract: Vesting;
+    let sqToken: ERC20;
+    let vestingContract: L2Vesting;
     const lockPeriod = 86400 * 30; // 2 month
     const vestingPeriod = 86400 * 365; // 1 year
     const initialUnlockPercent = 10;
@@ -41,10 +39,10 @@ describe('Vesting Contract', () => {
         return event?.args?.[0]?.toNumber();
     }
 
-    const startVesting = async () => {
+    const startVesting = async (planId: number) => {
         const latestBlock = await mockProvider.getBlock('latest');
         const vestingStart = latestBlock.timestamp + 1000;
-        await vestingContract.startVesting(vestingStart);
+        await vestingContract.startVesting(planId, vestingStart);
         return vestingStart;
     };
 
@@ -57,19 +55,17 @@ describe('Vesting Contract', () => {
 
     const checkAllocation = async (planId: number, user: string, allocation: number, vtsqtBalance = allocation) => {
         expect(await vestingContract.allocations(planId, user)).to.equal(parseEther(allocation));
-        expect(await vtSQToken.balanceOf(user)).to.equal(parseEther(vtsqtBalance));
     };
 
-    const deployer = () => deployRootContracts(wallet, wallet1);
+    const deployer = () => deployContracts(wallet, wallet1);
 
     beforeEach(async () => {
         const deployment = await waffle.loadFixture(deployer);
-        sqToken = deployment.rootToken;
-        vestingContract = deployment.vesting;
-        vtSQToken = deployment.vtSQToken;
+        sqToken = deployment.token;
+        vestingContract = deployment.l2Vesting;
     });
 
-    describe('Vesting Plan', () => {
+    describe('L2Vesting Plan', () => {
         it('add vesting plan should work', async () => {
             // 0 initial unlock
             await expect(vestingContract.addVestingPlan(lockPeriod, vestingPeriod, 0))
@@ -114,7 +110,19 @@ describe('Vesting Contract', () => {
         it('allocate vesting should work', async () => {
             await vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)]);
             await checkAllocation(0, wallet1.address, 1000);
-            expect(await vestingContract.totalAllocation()).to.equal(parseEther(1000));
+            const plan = await vestingContract.plans(0);
+            expect(plan.totalAllocation).to.equal(parseEther(1000));
+        });
+
+        it('allocate same account multiple times', async () => {
+            await vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)]);
+            await checkAllocation(0, wallet1.address, 1000);
+            let plan = await vestingContract.plans(0);
+            expect(plan.totalAllocation).to.equal(parseEther(1000));
+            await vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)]);
+            await checkAllocation(0, wallet1.address, 2000);
+            plan = await vestingContract.plans(0);
+            expect(plan.totalAllocation).to.equal(parseEther(2000));
         });
 
         it('allocate same account multiple plan should work', async () => {
@@ -122,7 +130,10 @@ describe('Vesting Contract', () => {
             await checkAllocation(0, wallet1.address, 1000);
             await vestingContract.batchAllocateVesting([1], [wallet1.address], [parseEther(3000)]);
             await checkAllocation(1, wallet1.address, 3000, 4000);
-            expect(await vestingContract.totalAllocation()).to.equal(parseEther(4000));
+            const plan0 = await vestingContract.plans(0);
+            const plan1 = await vestingContract.plans(1);
+            expect(plan0.totalAllocation).to.equal(parseEther(1000));
+            expect(plan1.totalAllocation).to.equal(parseEther(3000));
         });
 
         it('batch allocate vesting should work', async () => {
@@ -144,7 +155,8 @@ describe('Vesting Contract', () => {
 
             await checkAllocation(0, wallet1.address, 1000);
             await checkAllocation(0, wallet2.address, 3000);
-            expect(await vestingContract.totalAllocation()).to.equal(parseEther(4000));
+            const plan = await vestingContract.plans(0);
+            expect(plan.totalAllocation).to.equal(parseEther(4000));
         });
 
         it('allocate with invaid config should fail', async () => {
@@ -157,11 +169,6 @@ describe('Vesting Contract', () => {
             await expect(
                 vestingContract.batchAllocateVesting([0], [emptyAddress], [parseEther(1000)])
             ).to.be.revertedWith('V002');
-            // duplicate account
-            await vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)]);
-            await expect(
-                vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)])
-            ).to.be.revertedWith('V003');
             // zero amount
             await expect(
                 vestingContract.batchAllocateVesting([0], [wallet2.address], [parseEther(0)])
@@ -182,30 +189,10 @@ describe('Vesting Contract', () => {
         });
     });
 
-    describe('Vesting Token vtSQT', () => {
-        beforeEach(async () => {
-            await vestingContract.addVestingPlan(lockPeriod, vestingPeriod, 10);
-        });
-
-        it('vtSQT can not burn without approval unless it is from minter', async () => {
-            const balance0 = await vtSQToken.balanceOf(wallet1.address);
-            expect(balance0).to.eq(0);
-            await vestingContract.batchAllocateVesting([0], [wallet1.address], [parseEther(1000)]);
-            const balance1 = await vtSQToken.balanceOf(wallet1.address);
-            expect(balance1).to.eq(parseEther(1000));
-            expect(vtSQToken.connect(wallet2).burnFrom(wallet1.address, balance1)).to.reverted;
-            await vtSQToken.setMinter(wallet2.address);
-            expect(vtSQToken.connect(wallet2).burnFrom(wallet1.address, balance1)).not.to.reverted;
-            const balance2 = await vtSQToken.balanceOf(wallet1.address);
-            expect(balance2).to.eq(0);
-        });
-    });
-
     describe('Token Manangement By Admin', () => {
         it('withdraw all by admin should work', async () => {
             await vestingContract.withdrawAllByAdmin();
             expect(await sqToken.balanceOf(vestingContract.address)).to.eq(parseEther(0));
-            expect(await vtSQToken.totalSupply()).to.eq(0);
         });
 
         it('withdraw without owner should fail', async () => {
@@ -214,8 +201,9 @@ describe('Vesting Contract', () => {
     });
 
     describe('Start Vesting', () => {
+        let planId: number;
         beforeEach(async () => {
-            const planId = await createPlan(lockPeriod, vestingPeriod);
+            planId = await createPlan(lockPeriod, vestingPeriod);
             await vestingContract.batchAllocateVesting(
                 [planId, planId],
                 [wallet1.address, wallet2.address],
@@ -223,39 +211,20 @@ describe('Vesting Contract', () => {
             );
         });
 
-        it('mint vtSQToken should work', async () => {
-            expect(await vtSQToken.totalSupply()).to.equal(parseEther(4000));
-            expect(await vtSQToken.balanceOf(wallet1.address)).to.equal(parseEther(1000));
-            expect(await vtSQToken.balanceOf(wallet2.address)).to.equal(parseEther(3000));
-        });
-
-        it('set incorrect vesting date should fail', async () => {
-            const latestBlock = await mockProvider.getBlock('latest');
-            await expect(vestingContract.startVesting(latestBlock.timestamp)).to.be.revertedWith('V009');
-        });
-
-        it('start vesting without enough balance should fail', async () => {
-            expect(await sqToken.balanceOf(vestingContract.address)).to.equal(parseEther(0));
-            const latestBlock = await mockProvider.getBlock('latest');
-            await expect(vestingContract.startVesting(latestBlock.timestamp + 1000)).to.be.revertedWith('V010');
-        });
-
         it('start vesting should work', async () => {
             const latestBlock = await mockProvider.getBlock('latest');
-            // await vestingContract.depositByAdmin(parseEther(4000));
             await sqToken.transfer(vestingContract.address, utils.parseEther('4000'));
 
             const startDate = latestBlock.timestamp + 1000;
-            await vestingContract.startVesting(startDate);
-            expect(await vestingContract.vestingStartDate()).to.equal(startDate);
-            expect(await vestingContract.owner()).to.equal(vestingContract.address);
+            await vestingContract.startVesting(planId, startDate);
+            const plan = await vestingContract.plans(planId);
+            expect(plan.startDate).to.equal(startDate);
+            // expect(await vestingContract.owner()).to.equal(vestingContract.address);
 
-            await expect(vestingContract.withdrawAllByAdmin()).to.be.revertedWith(ownableRevert);
-            await expect(vestingContract.addVestingPlan(0, 0, 10)).to.be.revertedWith(ownableRevert);
-            // await expect(vestingContract.allocateVesting(wallet1.address, 0, 0)).to.be.revertedWith(ownableRevert);
-            await expect(vestingContract.batchAllocateVesting([1], [wallet1.address], [0])).to.be.revertedWith(
-                ownableRevert
-            );
+            await expect(vestingContract.withdrawAllByAdmin()).not.to.be.reverted;
+            await expect(vestingContract.addVestingPlan(0, 0, 10)).not.to.be.reverted;
+            await expect(vestingContract.batchAllocateVesting([0], [wallet1.address], [10])).not.to.be.reverted;
+            await expect(vestingContract.batchAllocateVesting([1], [wallet1.address], [10])).not.to.be.reverted;
         });
     });
 
@@ -284,7 +253,8 @@ describe('Vesting Contract', () => {
             expect(await vestingContract.claimableAmount(planId, wallet1.address)).to.equal(0);
             expect(await vestingContract.claimableAmount(planId, wallet2.address)).to.equal(0);
             // no allocation for the users
-            await startVesting();
+            await startVesting(planId);
+            await startVesting(planId2);
             expect(await vestingContract.claimableAmount(planId, wallet4.address)).to.equal(0);
             await timeTravel(500);
             // not reach start date
@@ -296,7 +266,8 @@ describe('Vesting Contract', () => {
 
         it('claim during vesting period', async () => {
             // start vesting
-            const startDate = await startVesting();
+            const startDate = await startVesting(planId);
+            await startVesting(planId2);
             await timeTravelTo(startDate + lockPeriod + 1, 3600);
 
             let claimable = await vestingContract.claimableAmount(planId, wallet1.address);
@@ -334,7 +305,8 @@ describe('Vesting Contract', () => {
 
         it('claim all together in once', async () => {
             // start vesting
-            await startVesting();
+            await startVesting(planId);
+            await startVesting(planId2);
             await timeTravel(lockPeriod + vestingPeriod + 1001);
 
             let claimable = await vestingContract.claimableAmount(planId, wallet1.address);
@@ -345,9 +317,27 @@ describe('Vesting Contract', () => {
             expect(claimable).to.eq(0);
         });
 
+        it('start vesting separatedly and claim', async () => {
+            // start vesting
+            await startVesting(planId);
+            await timeTravel(lockPeriod + vestingPeriod + 1001);
+            expect(await sqToken.balanceOf(wallet3.address)).to.eq(0);
+            let claimable = await vestingContract.claimableAmount(planId, wallet3.address);
+            expect(claimable).to.eq(wallet3Allocation0);
+            await claimVesting(planId, wallet3);
+            expect(await sqToken.balanceOf(wallet3.address)).to.eq(wallet3Allocation0);
+            await startVesting(planId2);
+            await timeTravel(lockPeriod + vestingPeriod + 1001);
+            claimable = await vestingContract.claimableAmount(planId2, wallet3.address);
+            expect(claimable).to.eq(wallet3Allocation1);
+            await claimVesting(planId2, wallet3);
+            expect(await sqToken.balanceOf(wallet3.address)).to.eq(wallet3Allocation0.add(wallet3Allocation1));
+        });
+
         it('claim for should work', async () => {
             // start vesting
-            await startVesting();
+            await startVesting(planId);
+            await startVesting(planId2);
             await timeTravel(lockPeriod + vestingPeriod + 1001);
             const balance1 = await sqToken.balanceOf(wallet1.address);
             expect(balance1).to.eq(0);
@@ -362,7 +352,8 @@ describe('Vesting Contract', () => {
 
         it('claim should work', async () => {
             // start vesting
-            await startVesting();
+            await startVesting(planId);
+            await startVesting(planId2);
             await timeTravel(lockPeriod + 1001);
             // check initial release
             let claimable1 = await vestingContract.claimableAmount(planId, wallet1.address);
@@ -391,38 +382,6 @@ describe('Vesting Contract', () => {
             expect(await sqToken.balanceOf(wallet1.address)).to.eq(parseEther(1000));
         });
 
-        it('should burn equal amount of vtSQToken for claimed SQT', async () => {
-            // start vesting
-            await startVesting();
-            await timeTravel(lockPeriod + 1001);
-            // wallet1 claim
-            expect(await sqToken.balanceOf(wallet1.address)).to.eq(0);
-            expect(await vtSQToken.balanceOf(wallet1.address)).to.eq(parseEther(1000));
-            await vestingContract.connect(wallet1).claim(planId);
-            const sqtBalance = await sqToken.balanceOf(wallet1.address);
-            expect(await vtSQToken.balanceOf(wallet1.address)).to.eq(parseEther(1000).sub(sqtBalance));
-        });
-
-        it('should only claim max amount of VTSQToken', async () => {
-            // start vesting
-            await startVesting();
-            await timeTravel(lockPeriod + 1001);
-            // wallet1
-            expect(await sqToken.balanceOf(wallet1.address)).to.eq(0);
-            const unlockAmount = await vestingContract.unlockedAmount(planId, wallet1.address);
-            // transfer VTSQToken to wallet2
-            await vtSQToken.connect(wallet1).transfer(wallet2.address, etherParse('999'));
-            // unlockAmount > 1 SQT, vtSQToken balance = 1 vtSQT
-            expect(unlockAmount.gt(etherParse('1'))).to.be.true;
-            const claimableAmount = etherParse('1');
-            expect(await vestingContract.claimableAmount(planId, wallet1.address)).to.eq(claimableAmount);
-
-            // check SQT and VTSQT balance
-            await vestingContract.connect(wallet1).claim(planId);
-            expect(await sqToken.balanceOf(wallet1.address)).to.eq(claimableAmount);
-            expect(await vtSQToken.balanceOf(wallet1.address)).to.eq(0);
-        });
-
         it('claim with invalid condition should fail', async () => {
             // claim on non-vesting account should fail
             await expect(vestingContract.connect(wallet4).claim(planId)).to.be.revertedWith('V011');
@@ -430,88 +389,6 @@ describe('Vesting Contract', () => {
             // claim with zero claimable amount should fail
             // # case 1 (not start vesting)
             await expect(vestingContract.connect(wallet1).claim(planId)).to.be.revertedWith('V012');
-            // # case 2 (not enough vtSQT)
-            await startVesting();
-            await timeTravel(lockPeriod + 1001);
-            await vtSQToken.connect(wallet1).transfer(wallet2.address, etherParse('1000'));
-            await expect(vestingContract.connect(wallet1).claim(planId)).to.be.revertedWith('V012');
-        });
-    });
-
-    describe('Real Vesting Scenario Test', () => {
-        const startDate = new Date('2024-02-23T08:00:00Z').getTime() / 1000;
-        const secPerMonth = 2628000; // 3600*24*365/12
-        beforeEach(async () => {
-            // set up vesting
-            // create plans
-            for (const plan of PLANS) {
-                const tx = await vestingContract.addVestingPlan(
-                    plan.lockPeriod,
-                    plan.vestingPeriod,
-                    plan.initialUnlockPercent
-                );
-                const { planId, lockPeriod, vestingPeriod, initialUnlockPercent } = await eventFrom(
-                    tx,
-                    vestingContract,
-                    'VestingPlanAdded(uint256,uint256,uint256,uint256)'
-                );
-                expect(planId).to.eq(plan.planId);
-                expect(lockPeriod).to.eq(plan.lockPeriod);
-                expect(planId).to.eq(plan.planId);
-                expect(planId).to.eq(plan.planId);
-            }
-        });
-
-        // each plan has one wallet
-        // need to fix test, the start date has passed, so it will fail
-        it.skip('should unlock token according to the plan', async () => {
-            const wallets = [b0, b1, b2, b3, b4, b5];
-            for (const [planId, { total }] of EXPECTATION.entries()) {
-                await vestingContract.batchAllocateVesting([planId], [wallets[planId].address], [parseEther(total)]);
-            }
-            // start vesting (set the date, transfer token)
-            const total = EXPECTATION.reduce((acc, { total }) => acc.add(total), BigNumber.from(0));
-            await sqToken.transfer(vestingContract.address, utils.parseEther(total.toString()));
-            // await mockProvider.send('evm_setNextBlockTimestamp', [startDate-1000]);
-            // await mockProvider.send('evm_mine', []);
-            await vestingContract.startVesting(startDate);
-            for (const [planId, wallet] of wallets.entries()) {
-                const allocation = await vestingContract.allocations(planId, wallet.address);
-                await vtSQToken.connect(wallet).approve(vestingContract.address, allocation);
-            }
-
-            await timeTravelTo(startDate, 3600);
-            let currentDate = startDate;
-            for (let month = 1; month <= 60; month++) {
-                currentDate = currentDate + secPerMonth;
-                await timeTravelTo(currentDate, 3600);
-                const time = await lastestBlockTime();
-                for (let planId = 0; planId < 6; planId++) {
-                    const wallet = wallets[planId];
-                    const monthlyExpect = EXPECTATION[planId].monthly[month];
-                    if (monthlyExpect !== undefined) {
-                        const target = utils.parseEther(monthlyExpect.toString());
-                        const claimable = await vestingContract.claimableAmount(planId, wallet.address);
-                        if (monthlyExpect === 0 && EXPECTATION[planId].monthly[month + 1] === 0) {
-                            expect(claimable).to.eq(0);
-                        }
-                        if (claimable.gt(0) && monthlyExpect > 0) {
-                            await vestingContract.connect(wallet).claim(planId);
-                            const balance = await sqToken.balanceOf(wallet.address);
-                            // difference should < 0.01%
-                            expect(balance.sub(target).abs().mul(10000).div(target)).to.eq(0);
-                        }
-                        if (EXPECTATION[planId].monthly[month + 1] === undefined) {
-                            const balance = await sqToken.balanceOf(wallet.address);
-                            expect(balance).to.eq(utils.parseEther(EXPECTATION[planId].total.toString()));
-                            console.log(`planId: ${planId}, matches`);
-                        }
-                    }
-                }
-            }
-
-            const balance = await sqToken.balanceOf(vestingContract.address);
-            expect(balance).to.eq(0);
         });
     });
 });


### PR DESCRIPTION
Simplified vesting contract and plan to make it usable on Base

* remove vtSQT stuff
* upgradable and not locked after start
* startDate moved to per plan level along with totalAllocated and totalClaimed
* can start new plan vesting separatedly