### PR TITLE
implement reward cap and commission cap

### DIFF
--- a/contracts/RewardsDistributor.sol
+++ b/contracts/RewardsDistributor.sol
@@ -79,11 +79,11 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
 
     /// @notice perMill, <max commission> = <selfStake> * <maxCommissionFactor>
     /// 0: disabled
-    uint256 maxCommissionFactor;
+    uint256 public maxCommissionFactor;
 
     /// @notice perMill, <max pool reward> = <totalStake> * <maxRewardFactor>
     /// 0: disabled
-    uint256 maxRewardFactor;
+    uint256 public maxRewardFactor;
 
     /// @dev ### EVENTS
     /// @notice Emitted when rewards are distributed for the earliest pending distributed Era.
@@ -373,8 +373,8 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
             ).getCommissionRate(runner);
             uint256 commission = commissionRate.mulDiv(rewardInfo.eraReward, PER_MILL);
 
-            // 1. total reward can not greater than factor2 * total_stake
-            // 2. commission can not greater than factor * self_stake
+            // 1. total reward can not greater than maxRewardFactor * totalStake
+            // 2. commission can not greater than maxCommissionFactor * selfStake
             uint256 cappedReward = maxRewardFactor > 0
                 ? MathUtil.min(rewardInfo.eraReward, totalStake.mulDiv(maxRewardFactor, PER_MILL))
                 : rewardInfo.eraReward;

--- a/contracts/RewardsDistributor.sol
+++ b/contracts/RewardsDistributor.sol
@@ -399,10 +399,11 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
             }
 
             emit DistributeRewards(runner, rewardInfo.lastClaimEra, cappedReward, cappedCommission);
-
             if (rewardInfo.eraReward - cappedReward > 0 || commission - cappedCommission > 0) {
                 uint256 rewardsReturn;
-                rewardsReturn += rewardInfo.eraReward - cappedReward;
+                rewardsReturn +=
+                    (rewardInfo.eraReward - commission) -
+                    (cappedReward.sub(cappedCommission));
                 rewardsReturn += commission - cappedCommission;
                 address treasury = ISettings(settings).getContractAddress(SQContracts.Treasury);
                 SQToken.safeTransfer(treasury, rewardsReturn);

--- a/contracts/RewardsDistributor.sol
+++ b/contracts/RewardsDistributor.sol
@@ -77,6 +77,14 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
     /// @notice Reward information: runner => RewardInfo
     mapping(address => RewardInfo) private info;
 
+    /// @notice perMill, <max commission> = <selfStake> * <maxCommissionFactor>
+    /// 0: disabled
+    uint256 maxCommissionFactor;
+
+    /// @notice perMill, <max pool reward> = <totalStake> * <maxRewardFactor>
+    /// 0: disabled
+    uint256 maxRewardFactor;
+
     /// @dev ### EVENTS
     /// @notice Emitted when rewards are distributed for the earliest pending distributed Era.
     event DistributeRewards(
@@ -98,6 +106,8 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
     event InstantRewards(address indexed runner, uint256 indexed eraIdx, uint256 token);
     /// @notice Emitted when rewards arrive via increaseAgreementRewards()
     event AgreementRewards(address indexed runner, uint256 agreementId, uint256 token);
+    /// @notice Emitted when rewards return to treasury due to exceed reward cap
+    event ReturnRewards(address indexed runner, uint256 token, uint256 commission);
 
     modifier onlyRewardsStaking() {
         require(msg.sender == settings.getContractAddress(SQContracts.RewardsStaking), 'G014');
@@ -117,6 +127,14 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
 
     function setSettings(ISettings _settings) external onlyOwner {
         settings = _settings;
+    }
+
+    function setMaxCommissionFactor(uint256 _maxCommissionFactor) external onlyOwner {
+        maxCommissionFactor = _maxCommissionFactor;
+    }
+
+    function setMaxRewardFactor(uint256 _maxRewardFactor) external onlyOwner {
+        maxRewardFactor = _maxRewardFactor;
     }
 
     /**
@@ -347,36 +365,53 @@ contract RewardsDistributor is IRewardsDistributor, Initializable, OwnableUpgrad
         delete rewardInfo.eraRewardRemoveTable[rewardInfo.lastClaimEra];
         if (rewardInfo.eraReward != 0) {
             uint256 totalStake = rewardsStaking.getTotalStakingAmount(runner);
+            uint256 selfStake = rewardsStaking.getDelegationAmount(runner, runner);
             require(totalStake > 0, 'RD006');
 
             uint256 commissionRate = IIndexerRegistry(
                 settings.getContractAddress(SQContracts.IndexerRegistry)
             ).getCommissionRate(runner);
-            uint256 commission = MathUtil.mulDiv(commissionRate, rewardInfo.eraReward, PER_MILL);
+            uint256 commission = commissionRate.mulDiv(rewardInfo.eraReward, PER_MILL);
 
-            info[runner].accSQTPerStake += MathUtil.mulDiv(
-                rewardInfo.eraReward - commission,
+            // 1. total reward can not greater than factor2 * total_stake
+            // 2. commission can not greater than factor * self_stake
+            uint256 cappedReward = maxRewardFactor > 0
+                ? MathUtil.min(rewardInfo.eraReward, totalStake.mulDiv(maxRewardFactor, PER_MILL))
+                : rewardInfo.eraReward;
+            uint256 cappedCommission = maxCommissionFactor > 0
+                ? MathUtil.min(commission, selfStake.mulDiv(maxCommissionFactor, PER_MILL))
+                : commission;
+            info[runner].accSQTPerStake += cappedReward.sub(cappedCommission).mulDiv(
                 PER_TRILL,
                 totalStake
             );
-            if (commission > 0) {
+            IERC20 SQToken = IERC20(settings.getContractAddress(SQContracts.SQToken));
+            if (cappedCommission > 0) {
                 // add commission to unbonding request
-                IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransfer(
+                SQToken.safeTransfer(
                     settings.getContractAddress(SQContracts.Staking),
-                    commission
+                    cappedCommission
                 );
                 IStaking(settings.getContractAddress(SQContracts.Staking)).unbondCommission(
                     runner,
-                    commission
+                    cappedCommission
                 );
             }
 
-            emit DistributeRewards(
-                runner,
-                rewardInfo.lastClaimEra,
-                rewardInfo.eraReward,
-                commission
-            );
+            emit DistributeRewards(runner, rewardInfo.lastClaimEra, cappedReward, cappedCommission);
+
+            if (rewardInfo.eraReward - cappedReward > 0 || commission - cappedCommission > 0) {
+                uint256 rewardsReturn;
+                rewardsReturn += rewardInfo.eraReward - cappedReward;
+                rewardsReturn += commission - cappedCommission;
+                address treasury = ISettings(settings).getContractAddress(SQContracts.Treasury);
+                SQToken.safeTransfer(treasury, rewardsReturn);
+                emit ReturnRewards(
+                    runner,
+                    rewardInfo.eraReward - cappedReward,
+                    commission - cappedCommission
+                );
+            }
         }
         return rewardInfo.lastClaimEra;
     }

--- a/contracts/StakingManager.sol
+++ b/contracts/StakingManager.sol
@@ -189,6 +189,15 @@ contract StakingManager is IStakingManager, Initializable, OwnableUpgradeable {
         return StakingUtil.currentStaking(sm, _currentEra);
     }
 
+    function getDelegationAmount(address _source, address _runner) public view returns (uint256) {
+        uint256 eraNumber = IEraManager(settings.getContractAddress(SQContracts.EraManager))
+            .eraNumber();
+        Staking staking = Staking(settings.getContractAddress(SQContracts.Staking));
+        (uint256 era, uint256 valueAt, uint256 valueAfter) = staking.delegation(_source, _runner);
+        StakingAmount memory sm = StakingAmount(era, valueAt, valueAfter);
+        return StakingUtil.currentStaking(sm, eraNumber);
+    }
+
     function getTotalStakingAmount(address _runner) public view override returns (uint256) {
         uint256 eraNumber = IEraManager(settings.getContractAddress(SQContracts.EraManager))
             .eraNumber();

--- a/publish/ABI/RewardsDistributor.json
+++ b/publish/ABI/RewardsDistributor.json
@@ -149,7 +149,7 @@
             {
                 "indexed": false,
                 "internalType": "uint256",
-                "name": "token",
+                "name": "rewards",
                 "type": "uint256"
             },
             {
@@ -427,6 +427,32 @@
         "name": "initialize",
         "outputs": [],
         "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxCommissionFactor",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxRewardFactor",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
         "type": "function"
     },
     {

--- a/publish/ABI/RewardsDistributor.json
+++ b/publish/ABI/RewardsDistributor.json
@@ -147,6 +147,31 @@
                 "type": "address"
             },
             {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "token",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "commission",
+                "type": "uint256"
+            }
+        ],
+        "name": "ReturnRewards",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "runner",
+                "type": "address"
+            },
+            {
                 "indexed": true,
                 "internalType": "uint256",
                 "name": "eraIdx",
@@ -456,6 +481,32 @@
             }
         ],
         "name": "setLastClaimEra",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_maxCommissionFactor",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMaxCommissionFactor",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_maxRewardFactor",
+                "type": "uint256"
+            }
+        ],
+        "name": "setMaxRewardFactor",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/publish/ABI/StakingManager.json
+++ b/publish/ABI/StakingManager.json
@@ -90,6 +90,30 @@
         "inputs": [
             {
                 "internalType": "address",
+                "name": "_source",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_runner",
+                "type": "address"
+            }
+        ],
+        "name": "getDelegationAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
                 "name": "_runner",
                 "type": "address"
             }

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -69,10 +69,9 @@ describe('RewardsDistributor Contract', () => {
         eraManager = deployment.eraManager;
 
         //init delegator account
-        await token.connect(root).transfer(runner.address, etherParse('10000'));
-        await token.connect(root).transfer(delegator.address, etherParse('10000'));
-        await token.connect(root).transfer(delegator2.address, etherParse('10000'));
-        await token.connect(root).transfer(consumer.address, etherParse('10000'));
+        await token.connect(root).transfer(delegator.address, etherParse('10'));
+        await token.connect(root).transfer(delegator2.address, etherParse('10'));
+        await token.connect(root).transfer(consumer.address, etherParse('10'));
         await token.connect(consumer).increaseAllowance(planManager.address, etherParse('10000'));
         await token.connect(delegator).increaseAllowance(staking.address, etherParse('10000'));
         await token.connect(delegator2).increaseAllowance(staking.address, etherParse('10000'));
@@ -134,6 +133,9 @@ describe('RewardsDistributor Contract', () => {
 
     describe('Capped Rewards', async () => {
         beforeEach(async () => {
+            await token.connect(root).transfer(runner.address, etherParse('10000'));
+            await token.connect(root).transfer(delegator.address, etherParse('10000'));
+            await token.connect(root).transfer(consumer.address, etherParse('10000'));
             await stakingManager.connect(delegator).delegate(runner.address, etherParse(9000));
             await startNewEra(eraManager);
             await rewardsHelper.connect(runner).indexerCatchup(runner.address);
@@ -222,14 +224,14 @@ describe('RewardsDistributor Contract', () => {
             expect((await rewardsHelper.getRewardsAddTable(runner.address, 2, 1))[0]).to.be.eq(etherParse('0'));
             expect((await rewardsHelper.getRewardsRemoveTable(runner.address, 2, 1))[0]).to.be.eq(etherParse('0'));
             await rewardsDistributor.connect(runner).claim(runner.address);
-
+            rewards = (await token.balanceOf(runner.address)).div(1e14);
             //move to Era 4
             await startNewEra(eraManager);
             await rewardsDistributor.collectAndDistributeRewards(runner.address);
             expect((await rewardsHelper.getRewardsAddTable(runner.address, 3, 1))[0]).to.be.eq(etherParse('0'));
             expect((await rewardsHelper.getRewardsRemoveTable(runner.address, 3, 1))[0]).to.be.eq(etherParse('0'));
             await rewardsDistributor.connect(runner).claim(runner.address);
-
+            rewards = (await token.balanceOf(runner.address)).div(1e14);
             //move to Era 5
             await startNewEra(eraManager);
             await rewardsDistributor.collectAndDistributeRewards(runner.address);

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -132,7 +132,7 @@ describe('RewardsDistributor Contract', () => {
         });
     });
 
-    describe.only('Capped Rewards', async () => {
+    describe('Capped Rewards', async () => {
         beforeEach(async () => {
             await stakingManager.connect(delegator).delegate(runner.address, etherParse(9000));
             await startNewEra(eraManager);

--- a/test/RewardsDistributer.test.ts
+++ b/test/RewardsDistributer.test.ts
@@ -17,7 +17,7 @@ import {
     StakingManager,
 } from '../src';
 import { DEPLOYMENT_ID, METADATA_HASH, VERSION } from './constants';
-import { acceptPlan, etherParse, startNewEra, time, timeTravel } from './helper';
+import { acceptPlan, addInstantRewards, etherParse, startNewEra, time, timeTravel } from './helper';
 import { deployContracts } from './setup';
 
 describe('RewardsDistributor Contract', () => {
@@ -128,6 +128,19 @@ describe('RewardsDistributor Contract', () => {
             );
             expect(eraReward).to.be.eq(0);
             expect(totalReward).to.be.eq(etherParse('3'));
+        });
+    });
+
+    describe.only('Capped Rewards', async () => {
+        beforeEach(async () => {});
+        it('receive capped commission', async () => {
+            // self stake 1000 SQT
+            // commission rate: 10%
+            // cap 0.1 times
+            // arrival rewards: 1500 SQT
+            // const arrivalReward =
+            const era = await eraManager.eraNumber();
+            await addInstantRewards(token, rewardsDistributor, consumer, runner.address, era, 1000);
         });
     });
 


### PR DESCRIPTION
### Changes - RewardsDistributor
Storage
* add  maxCommissionFactor
* add maxRewardFactor

Event
* add `event ReturnRewards(address indexed runner, uint256 token, uint256 commission)`

Function
* `function setMaxCommissionFactor(uint256 _maxCommissionFactor) external onlyOwner`
* `function setMaxRewardFactor(uint256 _maxRewardFactor) external onlyOwner`

Logic
* total reward can not greater than maxRewardFactor * totalStake
* commission can not greater than maxCommissionFactor * selfStake
* exceeded rewards is returned to treasury