### PR TITLE
fix approve issue when claim statechannel

### DIFF
--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -1361,11 +1361,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster, S
                 address(this),
                 _amount
             );
-            // Allowance
-            IERC20(settings.getContractAddress(SQContracts.SQToken)).safeIncreaseAllowance(
-                msg.sender,
-                _amount
-            );
+            sqToken.safeTransfer(msg.sender, _amount);
 
             emit QueryRewardsSpent(_deploymentId, _spender, _amount, _data);
         }
@@ -1396,11 +1392,7 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster, S
                 address(this),
                 _amount
             );
-            // Allowance
-            IERC20(settings.getContractAddress(SQContracts.SQToken)).safeIncreaseAllowance(
-                msg.sender,
-                _amount
-            );
+            sqToken.safeTransfer(msg.sender, _amount);
 
             emit QueryRewardsSpent(_deploymentId, _spender, _amount, _data);
         }

--- a/contracts/RewardsBooster.sol
+++ b/contracts/RewardsBooster.sol
@@ -1362,7 +1362,10 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster, S
                 _amount
             );
             // Allowance
-            IERC20(settings.getContractAddress(SQContracts.SQToken)).approve(msg.sender, _amount);
+            IERC20(settings.getContractAddress(SQContracts.SQToken)).safeIncreaseAllowance(
+                msg.sender,
+                _amount
+            );
 
             emit QueryRewardsSpent(_deploymentId, _spender, _amount, _data);
         }
@@ -1394,7 +1397,10 @@ contract RewardsBooster is Initializable, OwnableUpgradeable, IRewardsBooster, S
                 _amount
             );
             // Allowance
-            IERC20(settings.getContractAddress(SQContracts.SQToken)).approve(msg.sender, _amount);
+            IERC20(settings.getContractAddress(SQContracts.SQToken)).safeIncreaseAllowance(
+                msg.sender,
+                _amount
+            );
 
             emit QueryRewardsSpent(_deploymentId, _spender, _amount, _data);
         }

--- a/contracts/StateChannel.sol
+++ b/contracts/StateChannel.sol
@@ -327,13 +327,6 @@ contract StateChannel is Initializable, OwnableUpgradeable, SQParameter {
             amount,
             abi.encode(channelId)
         );
-        if (rewardsAmount > 0) {
-            IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransferFrom(
-                rbAddress,
-                address(this),
-                rewardsAmount
-            );
-        }
 
         if (rewardsAmount < amount) {
             // transfer the balance to contract
@@ -592,13 +585,6 @@ contract StateChannel is Initializable, OwnableUpgradeable, SQParameter {
                 spent - rewardsTotal,
                 abi.encode(channelId)
             );
-            if (rewardsAmount > 0) {
-                IERC20(settings.getContractAddress(SQContracts.SQToken)).safeTransferFrom(
-                    rbAddress,
-                    address(this),
-                    rewardsAmount
-                );
-            }
             total += rewardsAmount;
         }
 

--- a/test/RewardsBooster_migration.test.ts
+++ b/test/RewardsBooster_migration.test.ts
@@ -682,8 +682,8 @@ describe('RewardsBooster Contract', () => {
             expect(evts.length).to.eq(2);
             // 3 block passed (upgrade, migrateDeploymentBoost, collectAllocationReward) since we queried alReward0,
             // and 1 of them counts on old rewards, so we should get 500.5 SQT * 103 (availabe secs) / 1003 (total secs) = 51.397308075772681954
-            // sometimes the test takes longer than 3 sec for 3 blocks, so result may become 51844
-            expect(evts[0].amount.div((1e15).toString()).toString()).to.be.oneOf(['51397', '51844']);
+            // sometimes the test takes longer than 3 sec for 3 blocks, so result may become 52291
+            expect(evts[0].amount.div((1e15).toString()).toNumber()).to.within(51397, 52291);
             // 1 block(collectAllocationReward) passed for new reward pool, so we should get 1.25 SQT more
             expect(evts[1].amount).to.lt(etherParse('1.25'));
             await blockTravel(999);


### PR DESCRIPTION
This pr will solve the no enough allowance issue when statechannel claims.
The problem is `approve()` was used and since we now switch to claim rewards in both old pool and new pool, the second approve() will overwrite the first one.