### PR TITLE
Added "moveAllocation"  method to StakingAllocation contract

### DIFF
--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -51,7 +51,6 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     // -- Events --
     event StakeAllocationAdded(bytes32 deploymentId, address runner, uint256 amount);
     event StakeAllocationRemoved(bytes32 deploymentId, address runner, uint256 amount);
-    event StakeAllocationMoved(bytes32 deploymentIdFrom, bytes32 deploymentIdTo, address runner, uint256 amount);
     event OverAllocationStarted(address runner, uint256 start);
     event OverAllocationEnded(address runner, uint256 end, uint256 time);
     // -- Functions --
@@ -120,14 +119,8 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         require(allocatedTokens[_runner][_deploymentFrom] >= _amount, 'SAL04');
         require(_deploymentFrom != _deploymentTo, 'SAL07');
 
-        RunnerAllocation storage ia = _runnerAllocations[_runner];
-
-        require(ia.used <= ia.total , 'SAL03');
-
         _removeAllocation(_deploymentFrom, _runner, _amount);
         _addAllocation(_deploymentTo, _runner, _amount);
-
-        emit StakeAllocationMoved(_deploymentFrom, _deploymentTo, _runner, _amount);
     }
 
     function stopService(bytes32 _deployment, address _runner) external {

--- a/contracts/StakingAllocation.sol
+++ b/contracts/StakingAllocation.sol
@@ -51,6 +51,7 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
     // -- Events --
     event StakeAllocationAdded(bytes32 deploymentId, address runner, uint256 amount);
     event StakeAllocationRemoved(bytes32 deploymentId, address runner, uint256 amount);
+    event StakeAllocationMoved(bytes32 deploymentIdFrom, bytes32 deploymentIdTo, address runner, uint256 amount);
     event OverAllocationStarted(address runner, uint256 start);
     event OverAllocationEnded(address runner, uint256 end, uint256 time);
     // -- Functions --
@@ -97,23 +98,14 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         require(_isAuth(_runner), 'SAL02');
         require(
             IProjectRegistry(settings.getContractAddress(SQContracts.ProjectRegistry))
-                .isServiceAvailable(_deployment, _runner),
+            .isServiceAvailable(_deployment, _runner),
             'SAL05'
         );
 
-        // collect rewards (if any) before change allocation
-        IRewardsBooster rb = IRewardsBooster(
-            settings.getContractAddress(SQContracts.RewardsBooster)
-        );
-        rb.collectAllocationReward(_deployment, _runner);
-
         RunnerAllocation storage ia = _runnerAllocations[_runner];
         require(ia.total - ia.used >= _amount, 'SAL03');
-        ia.used += _amount;
-        deploymentAllocations[_deployment] += _amount;
-        allocatedTokens[_runner][_deployment] += _amount;
 
-        emit StakeAllocationAdded(_deployment, _runner, _amount);
+        _addAllocation(_deployment, _runner, _amount);
     }
 
     function removeAllocation(bytes32 _deployment, address _runner, uint256 _amount) external {
@@ -121,6 +113,21 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         require(allocatedTokens[_runner][_deployment] >= _amount, 'SAL04');
 
         _removeAllocation(_deployment, _runner, _amount);
+    }
+
+    function moveAllocation(bytes32 _deploymentFrom, bytes32 _deploymentTo, address _runner, uint256 _amount) external {
+        require(_isAuth(_runner), 'SAL02');
+        require(allocatedTokens[_runner][_deploymentFrom] >= _amount, 'SAL04');
+        require(_deploymentFrom != _deploymentTo, 'SAL07');
+
+        RunnerAllocation storage ia = _runnerAllocations[_runner];
+
+        require(ia.used <= ia.total , 'SAL03');
+
+        _removeAllocation(_deploymentFrom, _runner, _amount);
+        _addAllocation(_deploymentTo, _runner, _amount);
+
+        emit StakeAllocationMoved(_deploymentFrom, _deploymentTo, _runner, _amount);
     }
 
     function stopService(bytes32 _deployment, address _runner) external {
@@ -132,12 +139,20 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         }
     }
 
+    function _addAllocation(bytes32 _deployment, address _runner, uint256 _amount) private {
+        _collectRewards(_deployment, _runner);
+
+        RunnerAllocation storage ia = _runnerAllocations[_runner];
+
+        ia.used += _amount;
+        deploymentAllocations[_deployment] += _amount;
+        allocatedTokens[_runner][_deployment] += _amount;
+
+        emit StakeAllocationAdded(_deployment, _runner, _amount);
+    }
+
     function _removeAllocation(bytes32 _deployment, address _runner, uint256 _amount) private {
-        // collect rewards (if any) before change allocation
-        IRewardsBooster rb = IRewardsBooster(
-            settings.getContractAddress(SQContracts.RewardsBooster)
-        );
-        rb.collectAllocationReward(_deployment, _runner);
+        _collectRewards(_deployment, _runner);
 
         RunnerAllocation storage ia = _runnerAllocations[_runner];
 
@@ -154,6 +169,14 @@ contract StakingAllocation is IStakingAllocation, Initializable, OwnableUpgradea
         }
 
         emit StakeAllocationRemoved(_deployment, _runner, _amount);
+    }
+
+    function _collectRewards(bytes32 _deployment, address _runner) private {
+        // collect rewards (if any) before change allocation
+        IRewardsBooster rb = IRewardsBooster(
+            settings.getContractAddress(SQContracts.RewardsBooster)
+        );
+        rb.collectAllocationReward(_deployment, _runner);
     }
 
     function runnerAllocation(address _runner) external view returns (RunnerAllocation memory) {

--- a/publish/revertcode.json
+++ b/publish/revertcode.json
@@ -201,6 +201,7 @@
     "SAL03": "Not enough staked token",
     "SAL04": "Not enough allocated token",
     "SAL05": "Deployment not exist",
+    "SAL07": "Source Deployment must be different than Destination Deployment",
     "RB001": "Invalid project type",
     "RB002": "Invalid boosterQueryRewardRate",
     "RB003": "Balance of booster deployment is not enought",

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -296,24 +296,6 @@ describe('StakingAllocation Contract', () => {
                 etherParse('0')
             );
 
-            //////////
-
-            await stakingManager.connect(runner1).delegate(runner0.address, etherParse('6000'));
-            await applyStaking(runner0, runner1);
-
-            await stakingAllocation.connect(runner0).addAllocation(deploymentId0, runner0.address, etherParse('6000'))
-
-            await stakingManager.connect(runner1).undelegate(runner0.address, etherParse('6000'));
-            await applyStaking(runner0, runner1);
-
-            await expect(
-                stakingAllocation.connect(runner0).moveAllocation(deploymentIds[0], deploymentIds[1], runner0.address, etherParse('6000'))
-            ).to.revertedWith('SAL03');
-
-            await stakingAllocation.connect(runner0).removeAllocation(deploymentId0, runner0.address, etherParse('6000'));
-
-
-
         });
 
         it('add allocation to a stopped project', async () => {

--- a/test/StakingAllocation.test.ts
+++ b/test/StakingAllocation.test.ts
@@ -242,6 +242,7 @@ describe('StakingAllocation Contract', () => {
             expect(da0).to.eq(etherParse('14000'));
             expect(da1).to.eq(etherParse('1000'));
 
+
             await expect(
                 stakingAllocation.connect(runner0).addAllocation(deploymentIds[1], runner0.address, etherParse('5001'))
             ).to.be.revertedWith('SAL03');
@@ -255,6 +256,8 @@ describe('StakingAllocation Contract', () => {
             await applyStaking(runner1, runner1);
             await checkAllocation(runner1, etherParse('9000'), etherParse('10000'), true, false);
             await timeTravel(10);
+
+
             await stakingAllocation
                 .connect(runner1)
                 .removeAllocation(deploymentIds[0], runner1.address, etherParse('500'));
@@ -263,6 +266,54 @@ describe('StakingAllocation Contract', () => {
                 .connect(runner1)
                 .removeAllocation(deploymentIds[0], runner1.address, etherParse('500'));
             await checkAllocation(runner1, etherParse('9000'), etherParse('9000'), false, true);
+
+            await expect(
+                stakingAllocation.connect(runner1).moveAllocation(deploymentIds[0], deploymentIds[0], runner1.address, etherParse('1000'))
+            ).to.revertedWith('SAL07');
+
+            await expect(
+                stakingAllocation.connect(runner1).moveAllocation(deploymentIds[0], deploymentIds[1], runner1.address, etherParse('1199000'))
+            ).to.revertedWith('SAL04');
+
+
+            await stakingAllocation
+                .connect(runner1)
+                .moveAllocation(deploymentIds[0], deploymentIds[1], runner1.address, etherParse('1000'));
+            expect(await stakingAllocation.allocatedTokens(runner1.address, deploymentIds[0])).to.eq(
+                etherParse('8000')
+            );
+            expect(await stakingAllocation.allocatedTokens(runner1.address, deploymentIds[1])).to.eq(
+                etherParse('1000')
+            );
+
+            await stakingAllocation
+                .connect(runner1)
+                .moveAllocation(deploymentIds[1], deploymentIds[0], runner1.address, etherParse('1000'));
+            expect(await stakingAllocation.allocatedTokens(runner1.address, deploymentIds[0])).to.eq(
+                etherParse('9000')
+            );
+            expect(await stakingAllocation.allocatedTokens(runner1.address, deploymentIds[1])).to.eq(
+                etherParse('0')
+            );
+
+            //////////
+
+            await stakingManager.connect(runner1).delegate(runner0.address, etherParse('6000'));
+            await applyStaking(runner0, runner1);
+
+            await stakingAllocation.connect(runner0).addAllocation(deploymentId0, runner0.address, etherParse('6000'))
+
+            await stakingManager.connect(runner1).undelegate(runner0.address, etherParse('6000'));
+            await applyStaking(runner0, runner1);
+
+            await expect(
+                stakingAllocation.connect(runner0).moveAllocation(deploymentIds[0], deploymentIds[1], runner0.address, etherParse('6000'))
+            ).to.revertedWith('SAL03');
+
+            await stakingAllocation.connect(runner0).removeAllocation(deploymentId0, runner0.address, etherParse('6000'));
+
+
+
         });
 
         it('add allocation to a stopped project', async () => {
@@ -277,6 +328,7 @@ describe('StakingAllocation Contract', () => {
 
             await stakingAllocation.connect(runner0).addAllocation(deploymentId0, runner0.address, etherParse('5000'));
             await checkAllocation(runner0, etherParse('10000'), etherParse('5000'), false, false);
+
         });
 
         it('over-allocate and recover', async () => {


### PR DESCRIPTION
# Added "moveAllocation"  method to StakingAllocation contract.


## Reason: 
Reducing the number of transactions and commission payments during weekly allocation changes.

Which will allow you to transfer part or all of the allocation to another project without first deleting the allocation


## Contract modifications:
```
event - StakeAllocationMoved with params  (deploymentIdFrom, deploymentIdTo, runner, amount)
public method: moveAllocation width params (_deploymentFrom, _deploymentTo, _runner, amount)

Modified logic for addAllocation. moved to  private method internal logic, and add data validation for public.
```

## Revertcode description:
```
"SAL07": "Source Deployment must be different than Destination Deployment",
```

## Test suite.
 - When tried to "move" allocation more then available. ( **SAL04** )
 - When source and destination address eq ( **SAL07** )
 - When current Allocation bigger then Available (unstake,undelegation) ( **SAL07** )
 - Move allocation for Project1 to Project2.

___
## Events...When moveAllocation method executed, we receive 3 events 

- StakeAllocationRemoved
- StakeAllocationAdded
- StakeAllocationMoved

This chain is made in order not to violate the logic of the SQ Mainnet subgraph.
