### PR TITLE
fix: channel consumer in consumerhost

### DIFF
--- a/contracts/ConsumerHost.sol
+++ b/contracts/ConsumerHost.sol
@@ -424,6 +424,11 @@ contract ConsumerHost is Initializable, OwnableUpgradeable, IConsumer, ERC165, S
         return abi.decode(callback, (address, bytes));
     }
 
+    function fixChannelConsumer(uint256 channelId, address consumer) external {
+        require(msg.sender == address('0x70d0AFeE4A6A314d71046DA9B4BbcFB8Fd1722Ce'), 'G011');
+        channels[channelId] = consumer;
+    }
+
     /**
      * @notice Check ERC165 interface
      * @param interfaceId interface ID

--- a/contracts/ConsumerHost.sol
+++ b/contracts/ConsumerHost.sol
@@ -433,7 +433,9 @@ contract ConsumerHost is Initializable, OwnableUpgradeable, IConsumer, ERC165, S
 
     function fixChannelConsumer(uint256 channelId, address consumer) external {
         require(msg.sender == address(0x70d0AFeE4A6A314d71046DA9B4BbcFB8Fd1722Ce), 'G011');
-        channels[channelId] = consumer;
+        if (channels[channelId] == address(0)) {
+            channels[channelId] = consumer;
+        }
     }
 
     /**

--- a/contracts/ConsumerHost.sol
+++ b/contracts/ConsumerHost.sol
@@ -424,6 +424,12 @@ contract ConsumerHost is Initializable, OwnableUpgradeable, IConsumer, ERC165, S
         return abi.decode(callback, (address, bytes));
     }
 
+    function setChannelConsumer(uint256 channelId, bytes memory callback) external {
+        require(msg.sender == settings.getContractAddress(SQContracts.StateChannel), 'G011');
+        (consumer, ) = this.decodeConsumerCallback(callback);
+        channels[channelId] = consumer;
+    }
+
     function fixChannelConsumer(uint256 channelId, address consumer) external {
         require(msg.sender == address(0x70d0AFeE4A6A314d71046DA9B4BbcFB8Fd1722Ce), 'G011');
         channels[channelId] = consumer;

--- a/contracts/ConsumerHost.sol
+++ b/contracts/ConsumerHost.sol
@@ -425,7 +425,7 @@ contract ConsumerHost is Initializable, OwnableUpgradeable, IConsumer, ERC165, S
     }
 
     function fixChannelConsumer(uint256 channelId, address consumer) external {
-        require(msg.sender == address('0x70d0AFeE4A6A314d71046DA9B4BbcFB8Fd1722Ce'), 'G011');
+        require(msg.sender == address(0x70d0AFeE4A6A314d71046DA9B4BbcFB8Fd1722Ce), 'G011');
         channels[channelId] = consumer;
     }
 

--- a/contracts/ConsumerHost.sol
+++ b/contracts/ConsumerHost.sol
@@ -426,6 +426,7 @@ contract ConsumerHost is Initializable, OwnableUpgradeable, IConsumer, ERC165, S
 
     function setChannelConsumer(uint256 channelId, bytes memory callback) external {
         require(msg.sender == settings.getContractAddress(SQContracts.StateChannel), 'G011');
+        address consumer;
         (consumer, ) = this.decodeConsumerCallback(callback);
         channels[channelId] = consumer;
     }

--- a/contracts/StateChannel.sol
+++ b/contracts/StateChannel.sol
@@ -673,6 +673,9 @@ contract StateChannel is Initializable, OwnableUpgradeable, SQParameter {
                 address(this),
                 realAmount
             );
+        } else if (isCConsumer) {
+            // so consumer contract know about relation between channelId and realconsumer
+            IConsumer(consumer).paid(channelId, msg.sender, 0, callback);
         }
 
         channels[channelId].realTotal += realAmount;

--- a/contracts/StateChannel.sol
+++ b/contracts/StateChannel.sol
@@ -657,6 +657,9 @@ contract StateChannel is Initializable, OwnableUpgradeable, SQParameter {
         if (isCConsumer) {
             IConsumer cConsumer = IConsumer(consumer);
             (realConsumer, ) = cConsumer.decodeConsumerCallback(callback);
+            if (cConsumer.channelConsumer(channelId) == address(0)) {
+                cConsumer.setChannelConsumer(channelId, callback);
+            }
         }
         // transfer the rewards to channel
         uint256 fundByReward = IRewardsBooster(
@@ -673,9 +676,6 @@ contract StateChannel is Initializable, OwnableUpgradeable, SQParameter {
                 address(this),
                 realAmount
             );
-        } else if (isCConsumer) {
-            // so consumer contract know about relation between channelId and realconsumer
-            IConsumer(consumer).paid(channelId, msg.sender, 0, callback);
         }
 
         channels[channelId].realTotal += realAmount;

--- a/contracts/interfaces/IConsumer.sol
+++ b/contracts/interfaces/IConsumer.sol
@@ -33,6 +33,8 @@ interface IConsumer {
     // Params: channel id
     function channelConsumer(uint256 channelId) external view returns (address);
 
+    function setChannelConsumer(uint256 channelId, bytes memory callback) external;
+
     function decodeConsumerCallback(
         bytes memory callback
     ) external pure returns (address, bytes memory);

--- a/publish/ABI/ConsumerHost.json
+++ b/publish/ABI/ConsumerHost.json
@@ -533,6 +533,24 @@
         "type": "function"
     },
     {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "channelId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "consumer",
+                "type": "address"
+            }
+        ],
+        "name": "fixChannelConsumer",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [],
         "name": "getSigners",
         "outputs": [

--- a/publish/ABI/ConsumerHost.json
+++ b/publish/ABI/ConsumerHost.json
@@ -688,6 +688,24 @@
     {
         "inputs": [
             {
+                "internalType": "uint256",
+                "name": "channelId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "callback",
+                "type": "bytes"
+            }
+        ],
+        "name": "setChannelConsumer",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
                 "internalType": "address",
                 "name": "controller",
                 "type": "address"


### PR DESCRIPTION
When a statechannel doesn't need to use consumerhost for the initial funding, it didn't call consumerhost.paid() therefore the relation between realuser <> channelId is missed in consumerhost.
This PR fixes the issue by introducing a new function `setChannelConsumer()`.
and `fixChannelConsumer(uint256 channelId, address consumer) ` for admin to fix the missing data for existing channels.